### PR TITLE
Enable blinking cursor in tmux config

### DIFF
--- a/home-modules/terminal/tmux.nix
+++ b/home-modules/terminal/tmux.nix
@@ -97,6 +97,11 @@ in
       # Basic terminal features
       set -as terminal-features ",*:RGB"
 
+      # Cursor settings - enable blinking cursor for active pane visibility
+      # Ss/Se enables cursor shape changes, blinking cursor makes active pane obvious
+      set -ga terminal-overrides ',*:Ss=\E[%p1%d q:Se=\E[2 q'
+      set -ga terminal-overrides ',*:Cs=\E]12;%p1%s\007:Cr=\E]112\007'
+
       # Pane settings
       set -g pane-base-index 0
       set -g renumber-windows on


### PR DESCRIPTION
Add terminal overrides to enable cursor blinking in tmux, making it more obvious which pane is currently active. This complements the existing background color contrast between active and inactive panes.

Changes:
- Added Ss/Se terminal overrides for cursor shape control
- Added Cs/Cr terminal overrides for cursor color/style control
- Enables blinking cursor in the active pane

To apply:
- WSL: sudo nixos-rebuild switch --flake .#wsl
- Hetzner: sudo nixos-rebuild switch --flake .#hetzner-sway
- M1 Mac: sudo nixos-rebuild switch --flake .#m1 --impure
- Or use: home-manager switch --flake .#<user>@<target>