### PR TITLE
feat(pwa): Route external URLs to PWAs by domain (Feature 113)

### DIFF
--- a/home-modules/profiles/base-home.nix
+++ b/home-modules/profiles/base-home.nix
@@ -71,6 +71,7 @@ in
     ../tools/docker.nix # Docker with 1Password authentication
     ../tools/pwa-helpers.nix  # PWA validation and helper commands (manual installation via Firefox GUI)
     ../tools/pwa-launcher.nix  # Dynamic PWA launcher with cross-machine compatibility
+    ../tools/pwa-url-router.nix  # Feature 113: Route external URLs to PWAs by domain
     # ../tools/web-apps-declarative.nix  # Chromium-based web app launcher - DISABLED (using Firefox PWAs instead)
     ../tools/clipcat.nix  # Clipboard history manager with X11 support (Feature 007)
     ../tools/screenshot-ocr.nix  # Screenshot (Spectacle) and OCR (gImageReader) tools
@@ -108,6 +109,7 @@ in
   modules.tools.fzf-file-search.enable = true;  # Floating fzf file search
   modules.tools.docker.enable = true; # Docker with 1Password integration
   modules.tools.remoteKubeconfig.enable = true;
+  programs.pwa-url-router.enable = true;  # Feature 113: Route external URLs to PWAs by domain
 
   # VSCode profile configuration
   # All VSCode instances (including activity-aware launchers) use this profile

--- a/home-modules/tools/firefox.nix
+++ b/home-modules/tools/firefox.nix
@@ -357,17 +357,28 @@ in
   # Set Firefox as the default browser for all browser-based activities
   # Using both defaultApplications (enforced) and associations.added (preferences)
   # This ensures OAuth flows work while allowing PWAs to register themselves
+  #
+  # Feature 113: URL scheme handlers (http/https) now route through pwa-url-router
+  # which opens PWAs for matching domains and falls back to Firefox for others.
+  # HTML files opened directly still use Firefox.
   xdg.mimeApps = {
     enable = true;
 
-    # Enforced defaults - critical for OAuth/authentication flows
+    # Enforced defaults
+    # Feature 113: http/https schemes route through PWA URL router for external app links
+    # The router checks if the URL domain matches a PWA, otherwise falls back to Firefox
     defaultApplications = {
+      # HTML files opened directly → Firefox (not affected by URL routing)
       "text/html" = "firefox.desktop";
-      "x-scheme-handler/http" = "firefox.desktop";
-      "x-scheme-handler/https" = "firefox.desktop";
+      "application/xhtml+xml" = "firefox.desktop";
+
+      # Feature 113: URL schemes → PWA URL Router (checks domain, falls back to Firefox)
+      "x-scheme-handler/http" = "pwa-url-router.desktop";
+      "x-scheme-handler/https" = "pwa-url-router.desktop";
+
+      # Non-web schemes → Firefox directly
       "x-scheme-handler/about" = "firefox.desktop";
       "x-scheme-handler/unknown" = "firefox.desktop";
-      "application/xhtml+xml" = "firefox.desktop";
     };
 
     # Additional associations - preferences, not enforced defaults

--- a/home-modules/tools/pwa-url-router.nix
+++ b/home-modules/tools/pwa-url-router.nix
@@ -1,0 +1,192 @@
+# Feature 113: PWA URL Router
+# Routes HTTP/HTTPS URLs to appropriate PWAs based on domain matching
+# Falls back to Firefox for non-matching URLs
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  # Import centralized PWA site definitions
+  pwaSitesConfig = import ../../shared/pwa-sites.nix { inherit lib; };
+  pwas = pwaSitesConfig.pwaSites;
+
+  # Generate PWA app name from display name (e.g., "GitHub" → "github-pwa")
+  mkPwaAppName = name: "${toLower (replaceStrings [" "] ["-"] name)}-pwa";
+
+  # Build domain → PWA mapping from routing_domains
+  # Only include PWAs that have non-empty routing_domains
+  domainMapping = let
+    # For each PWA with routing_domains, create entries for each domain
+    pwaEntries = builtins.concatMap (pwa:
+      let
+        domains = if pwa ? routing_domains then pwa.routing_domains else [ pwa.domain ];
+        appName = mkPwaAppName pwa.name;
+      in
+      if domains == [] then []
+      else builtins.map (domain: {
+        inherit domain;
+        pwa = appName;
+        ulid = pwa.ulid;
+        name = pwa.name;
+      }) domains
+    ) pwas;
+  in
+  builtins.listToAttrs (builtins.map (entry: {
+    name = entry.domain;
+    value = {
+      pwa = entry.pwa;
+      ulid = entry.ulid;
+      name = entry.name;
+    };
+  }) pwaEntries);
+
+  # Generate JSON registry file
+  domainRegistryJson = builtins.toJSON domainMapping;
+
+  # URL Router shell script
+  urlRouterScript = pkgs.writeShellScriptBin "pwa-url-router" ''
+    #!/usr/bin/env bash
+    # Feature 113: URL Router - Open URLs in PWAs when domain matches
+    # Only handles external app links; Firefox internal links stay in Firefox
+
+    set -euo pipefail
+
+    URL="''${1:-}"
+    DOMAIN_REGISTRY="$HOME/.config/i3/pwa-domains.json"
+    LOG_DIR="$HOME/.local/state"
+    LOG_FILE="$LOG_DIR/pwa-url-router.log"
+
+    # Ensure log directory exists
+    mkdir -p "$LOG_DIR"
+
+    log() {
+      echo "[$(date -Iseconds)] $*" >> "$LOG_FILE"
+    }
+
+    # Rotate log if too large (>1MB)
+    if [ -f "$LOG_FILE" ] && [ "$(stat -f%z "$LOG_FILE" 2>/dev/null || stat -c%s "$LOG_FILE" 2>/dev/null)" -gt 1048576 ]; then
+      mv "$LOG_FILE" "$LOG_FILE.old"
+    fi
+
+    if [ -z "$URL" ]; then
+      log "ERROR: No URL provided"
+      # Still open Firefox with no URL (new window)
+      exec ${pkgs.firefox}/bin/firefox
+    fi
+
+    log "Routing URL: $URL"
+
+    # Extract domain from URL (handles http://, https://, and URLs with ports/paths)
+    DOMAIN=$(echo "$URL" | ${pkgs.gnused}/bin/sed -E 's|^https?://||' | ${pkgs.gnused}/bin/sed -E 's|/.*||' | ${pkgs.gnused}/bin/sed -E 's|:.*||')
+
+    log "Extracted domain: $DOMAIN"
+
+    # Look up domain in registry
+    if [ -f "$DOMAIN_REGISTRY" ]; then
+      PWA_INFO=$(${pkgs.jq}/bin/jq -r --arg d "$DOMAIN" '.[$d] // empty' "$DOMAIN_REGISTRY" 2>/dev/null || echo "")
+
+      if [ -n "$PWA_INFO" ] && [ "$PWA_INFO" != "null" ]; then
+        PWA_DISPLAY=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.name')
+        PWA_APP_NAME=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.pwa')
+        PWA_ULID=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.ulid')
+        log "Match found: $DOMAIN → $PWA_APP_NAME ($PWA_DISPLAY, ULID: $PWA_ULID)"
+
+        # Launch PWA through app-launcher-wrapper for proper i3pm tracking
+        # Set I3PM_PWA_URL for deep linking - launch-pwa-by-name will pick this up
+        if command -v app-launcher-wrapper.sh >/dev/null 2>&1; then
+          log "Launching via wrapper: I3PM_PWA_URL=\"$URL\" app-launcher-wrapper.sh \"$PWA_APP_NAME\""
+          export I3PM_PWA_URL="$URL"
+          exec app-launcher-wrapper.sh "$PWA_APP_NAME"
+        elif command -v launch-pwa-by-name >/dev/null 2>&1; then
+          # Fallback: direct launch (won't have proper i3pm tracking)
+          log "WARNING: app-launcher-wrapper.sh not found, using direct launch (no i3pm tracking)"
+          log "Launching: launch-pwa-by-name \"$PWA_DISPLAY\" \"$URL\""
+          exec launch-pwa-by-name "$PWA_DISPLAY" "$URL"
+        else
+          log "ERROR: No launcher found, falling back to Firefox"
+          exec ${pkgs.firefox}/bin/firefox "$URL"
+        fi
+      fi
+    else
+      log "WARNING: Domain registry not found at $DOMAIN_REGISTRY"
+    fi
+
+    # No match - fallback to Firefox
+    log "No PWA match for $DOMAIN, opening in Firefox"
+    exec ${pkgs.firefox}/bin/firefox "$URL"
+  '';
+
+  # Diagnostic tool for testing routing
+  routeTestScript = pkgs.writeShellScriptBin "pwa-route-test" ''
+    #!/usr/bin/env bash
+    # Feature 113: Test PWA URL routing without actually opening anything
+
+    URL="''${1:-}"
+    DOMAIN_REGISTRY="$HOME/.config/i3/pwa-domains.json"
+
+    if [ -z "$URL" ]; then
+      echo "Usage: pwa-route-test <url>"
+      echo "Example: pwa-route-test https://github.com/user/repo"
+      exit 1
+    fi
+
+    # Extract domain from URL
+    DOMAIN=$(echo "$URL" | ${pkgs.gnused}/bin/sed -E 's|^https?://||' | ${pkgs.gnused}/bin/sed -E 's|/.*||' | ${pkgs.gnused}/bin/sed -E 's|:.*||')
+
+    echo "URL: $URL"
+    echo "Domain: $DOMAIN"
+    echo ""
+
+    if [ ! -f "$DOMAIN_REGISTRY" ]; then
+      echo "ERROR: Domain registry not found at $DOMAIN_REGISTRY"
+      echo "Run: nixos-rebuild switch to generate it"
+      exit 1
+    fi
+
+    PWA_INFO=$(${pkgs.jq}/bin/jq -r --arg d "$DOMAIN" '.[$d] // empty' "$DOMAIN_REGISTRY" 2>/dev/null || echo "")
+
+    if [ -n "$PWA_INFO" ] && [ "$PWA_INFO" != "null" ]; then
+      PWA_NAME=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.pwa')
+      PWA_DISPLAY=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.name')
+      PWA_ULID=$(echo "$PWA_INFO" | ${pkgs.jq}/bin/jq -r '.ulid')
+      echo "✓ Would route to: $PWA_NAME"
+      echo "  Display name: $PWA_DISPLAY"
+      echo "  ULID: $PWA_ULID"
+    else
+      echo "✗ No PWA match - would open in Firefox"
+    fi
+  '';
+
+in
+{
+  options.programs.pwa-url-router = {
+    enable = mkEnableOption "PWA URL routing for external links";
+  };
+
+  config = mkIf config.programs.pwa-url-router.enable {
+    # Install router scripts
+    home.packages = [
+      urlRouterScript
+      routeTestScript
+    ];
+
+    # Generate domain registry JSON
+    xdg.configFile."i3/pwa-domains.json" = {
+      text = domainRegistryJson;
+    };
+
+    # Generate desktop entry for URL handler
+    home.file.".local/share/applications/pwa-url-router.desktop".text = ''
+      [Desktop Entry]
+      Type=Application
+      Name=PWA URL Router
+      Comment=Routes URLs to PWAs or Firefox based on domain (Feature 113)
+      Exec=${urlRouterScript}/bin/pwa-url-router %u
+      Terminal=false
+      NoDisplay=true
+      MimeType=x-scheme-handler/http;x-scheme-handler/https;
+      StartupNotify=false
+      Categories=Network;WebBrowser;
+    '';
+  };
+}

--- a/shared/pwa-sites.nix
+++ b/shared/pwa-sites.nix
@@ -1,6 +1,7 @@
 # PWA Site Definitions - Single Source of Truth
 # This file contains all PWA metadata with ULID identifiers for cross-machine portability
 # Feature 106: Portable icon paths via assetsPackage
+# Feature 113: URL routing - routing_domains defines which domains open in this PWA
 { lib, assetsPackage ? null }:
 
 let
@@ -17,6 +18,8 @@ in
   #   - preferred_workspace: workspace number (50+ for PWAs, no upper bound; regular apps use 1-50)
   #   - preferred_monitor_role: (optional) "primary", "secondary", or "tertiary" - Feature 001: User Story 3
   #       If omitted, role is inferred from workspace number (WS 1-2→primary, 3-5→secondary, 6+→tertiary)
+  #   - routing_domains: (optional) list of domains that should open in this PWA - Feature 113
+  #       If omitted, defaults to [ domain ]. Use this to include www variants or related subdomains.
   pwaSites = [
     # YouTube
     {
@@ -33,6 +36,8 @@ in
       app_scope = "scoped";
       preferred_workspace = 50;
       preferred_monitor_role = "tertiary";  # Feature 001: Explicit tertiary assignment
+      # Feature 113: URL routing domains
+      routing_domains = [ "youtube.com" "www.youtube.com" "youtu.be" "m.youtube.com" ];
     }
 
     # Google AI (AI Mode Search)
@@ -49,6 +54,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 51;
+      # Feature 113: URL routing - only AI-specific paths, not general google.com
+      routing_domains = [ ];  # Disabled - google.com is too broad
     }
 
     # Claude (Anthropic AI)
@@ -66,6 +73,8 @@ in
       app_scope = "scoped";
       preferred_workspace = 52;
       preferred_monitor_role = "secondary";  # Feature 001: Explicit secondary assignment (dev tools on center monitor)
+      # Feature 113: URL routing domains
+      routing_domains = [ "claude.ai" "www.claude.ai" ];
     }
 
     # ChatGPT
@@ -82,6 +91,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 53;
+      # Feature 113: URL routing domains
+      routing_domains = [ "chatgpt.com" "www.chatgpt.com" "chat.openai.com" ];
     }
 
     # GitHub
@@ -98,6 +109,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 54;
+      # Feature 113: URL routing domains
+      routing_domains = [ "github.com" "www.github.com" ];
     }
 
     # GitHub Codespaces
@@ -114,6 +127,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 55;
+      # Feature 113: URL routing domains
+      routing_domains = [ "github.dev" ];
     }
 
     # Gmail
@@ -130,6 +145,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 56;
+      # Feature 113: URL routing domains
+      routing_domains = [ "mail.google.com" ];
     }
 
     # Google Calendar
@@ -146,6 +163,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 57;
+      # Feature 113: URL routing domains
+      routing_domains = [ "calendar.google.com" ];
     }
 
     # LinkedIn Learning
@@ -162,6 +181,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 58;
+      # Feature 113: URL routing - only learning subdomain, not all of linkedin
+      routing_domains = [ ];  # Disabled - linkedin.com is too broad
     }
 
     # Boston Dog Butlers
@@ -178,6 +199,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 59;
+      # Feature 113: URL routing domains
+      routing_domains = [ "bostondogbutlers.com" "www.bostondogbutlers.com" "www.timetopet.com" ];
     }
 
     # Microsoft Outlook
@@ -195,6 +218,8 @@ in
       app_scope = "global";
       preferred_workspace = 60;
       preferred_monitor_role = "secondary";  # Email client on center monitor
+      # Feature 113: URL routing domains
+      routing_domains = [ "outlook.office.com" "outlook.live.com" ];
     }
 
     # Hetzner Cloud Console
@@ -212,6 +237,8 @@ in
       app_scope = "global";
       preferred_workspace = 61;
       preferred_monitor_role = "tertiary";  # Infrastructure tools on tertiary monitor
+      # Feature 113: URL routing domains
+      routing_domains = [ "console.hetzner.cloud" ];
     }
 
     # Tailscale Admin Console
@@ -229,6 +256,8 @@ in
       app_scope = "global";
       preferred_workspace = 62;
       preferred_monitor_role = "tertiary";  # Network admin tools on tertiary monitor
+      # Feature 113: URL routing domains
+      routing_domains = [ "login.tailscale.com" "tailscale.com" "www.tailscale.com" ];
     }
 
     # Uber Eats
@@ -245,6 +274,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 63;
+      # Feature 113: URL routing domains
+      routing_domains = [ "ubereats.com" "www.ubereats.com" ];
     }
 
     # Home Assistant
@@ -261,6 +292,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 64;
+      # Feature 113: URL routing - localhost is too generic
+      routing_domains = [ ];  # Disabled - localhost:8123 would conflict with other local services
     }
 
     # 1Password
@@ -277,6 +310,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 65;
+      # Feature 113: URL routing domains
+      routing_domains = [ "pittampalli.1password.com" "my.1password.com" ];
     }
 
     # Perplexity
@@ -293,6 +328,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 66;
+      # Feature 113: URL routing domains
+      routing_domains = [ "perplexity.ai" "www.perplexity.ai" ];
     }
 
     # VS Code Web
@@ -309,6 +346,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 67;
+      # Feature 113: URL routing domains
+      routing_domains = [ "vscode.dev" "insiders.vscode.dev" ];
     }
 
     # Keycloak (Tailscale)
@@ -325,6 +364,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 68;
+      # Feature 113: URL routing domains
+      routing_domains = [ "keycloak.tail286401.ts.net" ];
     }
 
     # Backstage (Tailscale)
@@ -341,6 +382,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 69;
+      # Feature 113: URL routing domains
+      routing_domains = [ "cnoe.tail286401.ts.net" ];
     }
 
     # ArgoCD (Tailscale)
@@ -357,6 +400,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 70;
+      # Feature 113: URL routing domains
+      routing_domains = [ "argocd.tail286401.ts.net" ];
     }
 
     # ArgoCD (Talos/ai401kchat)
@@ -373,6 +418,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 77;
+      # Feature 113: URL routing domains
+      routing_domains = [ "argocd.ai401kchat.com" ];
     }
 
     # Gitea (Tailscale)
@@ -389,6 +436,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 71;
+      # Feature 113: URL routing domains
+      routing_domains = [ "gitea.tail286401.ts.net" ];
     }
 
     # CVS Pharmacy
@@ -405,6 +454,8 @@ in
       # App registry metadata
       app_scope = "global";
       preferred_workspace = 72;
+      # Feature 113: URL routing domains
+      routing_domains = [ "cvs.com" "www.cvs.com" ];
     }
 
     # Kargo (Tailscale)
@@ -421,6 +472,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 73;
+      # Feature 113: URL routing domains
+      routing_domains = [ "kargo.tail286401.ts.net" ];
     }
 
     # Headlamp (Tailscale)
@@ -437,6 +490,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 74;
+      # Feature 113: URL routing domains
+      routing_domains = [ "headlamp.tail286401.ts.net" ];
     }
 
     # Kagent (Tailscale)
@@ -453,6 +508,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 75;
+      # Feature 113: URL routing domains
+      routing_domains = [ "kagent.tail286401.ts.net" ];
     }
 
     # Agent Gateway (Tailscale)
@@ -469,6 +526,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 76;
+      # Feature 113: URL routing domains
+      routing_domains = [ "agentgateway.tail286401.ts.net" ];
     }
 
     # ============================================
@@ -490,6 +549,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 78;
+      # Feature 113: URL routing domains
+      routing_domains = [ "backstage.ai401kchat.com" ];
     }
 
     # Kargo (Talos/ai401kchat)
@@ -506,6 +567,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 79;
+      # Feature 113: URL routing domains
+      routing_domains = [ "kargo.ai401kchat.com" ];
     }
 
     # Headlamp (Talos/ai401kchat)
@@ -522,6 +585,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 80;
+      # Feature 113: URL routing domains
+      routing_domains = [ "headlamp.ai401kchat.com" ];
     }
 
     # Gitea (Talos/ai401kchat)
@@ -538,6 +603,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 81;
+      # Feature 113: URL routing domains
+      routing_domains = [ "gitea.ai401kchat.com" ];
     }
 
     # Keycloak (Talos/ai401kchat)
@@ -554,6 +621,8 @@ in
       # App registry metadata
       app_scope = "scoped";
       preferred_workspace = 82;
+      # Feature 113: URL routing domains
+      routing_domains = [ "keycloak.ai401kchat.com" ];
     }
   ];
 


### PR DESCRIPTION
## Summary

- Implement URL router that intercepts HTTP/HTTPS links from external applications
- Opens URLs in appropriate PWA when domain matches, falls back to Firefox otherwise
- Supports deep linking (full URL passed to PWA for specific page navigation)
- Routes through app-launcher-wrapper.sh for proper i3pm tracking with correct workspace bar icons

## Changes

- **pwa-url-router.nix**: New URL routing module with domain registry, router script, and desktop entry
- **pwa-sites.nix**: Add `routing_domains` field for per-PWA domain configuration
- **firefox.nix**: Use pwa-url-router for `x-scheme-handler/http(s)`
- **pwa-launcher.nix**: Support URL passthrough via `I3PM_PWA_URL` environment variable

## Test plan

- [x] `xdg-open "https://github.com/user/repo"` → Opens in GitHub PWA with correct icon
- [x] `xdg-open "https://www.youtube.com/watch?v=..."` → Opens in YouTube PWA with deep link
- [x] `xdg-open "https://example.com"` → Falls back to Firefox
- [x] `pwa-route-test <url>` → Shows routing decision without opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)