### PR TITLE
feat(pwa): Add tmux URL opener with PWA routing (Feature 113)

### DIFF
--- a/home-modules/terminal/tmux.nix
+++ b/home-modules/terminal/tmux.nix
@@ -228,6 +228,11 @@ in
       # -S - means capture from beginning of scrollback history (not just visible screen)
       bind u run-shell "tmux capture-pane -J -p -S - > /tmp/tmux-buffer-scan.txt && tmux display-popup -E -h 95% -w 95% tmux-url-scan"
 
+      # URL opener (prefix + o) - extract HTTP/HTTPS URLs and open with PWA routing (Feature 113)
+      # URLs matching PWA domains open in PWAs, others open in Firefox
+      # Uses fzf with multi-select, shows PWA indicators (🌐 = PWA, 🦊 = Firefox)
+      bind o run-shell "tmux capture-pane -J -p -S - > /tmp/tmux-buffer-scan.txt && tmux display-popup -E -h 95% -w 95% tmux-url-open"
+
 
       # Mouse scroll sensitivity - reduce scroll speed for precision
       # By default, tmux scrolls too fast (3 lines per wheel event)

--- a/home-modules/tools/pwa-launcher.nix
+++ b/home-modules/tools/pwa-launcher.nix
@@ -107,8 +107,8 @@ let
     # ============================================================================
     if [[ -n "$URL" ]]; then
       # Feature 113: Launch with URL for deep linking
-      # The -- separator ensures URL is passed as argument, not option
-      exec ${pkgs.firefoxpwa}/bin/firefoxpwa site launch "$PWA_ID" -- "$URL"
+      # Use --url flag to open PWA at specific URL
+      exec ${pkgs.firefoxpwa}/bin/firefoxpwa site launch "$PWA_ID" --url "$URL"
     else
       # Standard launch without URL
       exec ${pkgs.firefoxpwa}/bin/firefoxpwa site launch "$PWA_ID"

--- a/scripts/app-launcher-wrapper.sh
+++ b/scripts/app-launcher-wrapper.sh
@@ -460,6 +460,13 @@ if [[ -n "${I3PM_RESTORE_MARK:-}" ]]; then
     ENV_EXPORTS+=("export I3PM_RESTORE_MARK='$I3PM_RESTORE_MARK'")
 fi
 
+# Feature 113: Forward I3PM_PWA_URL for deep linking in PWAs
+# This allows pwa-url-router to pass the full URL to launch-pwa-by-name
+if [[ -n "${I3PM_PWA_URL:-}" ]]; then
+    ENV_EXPORTS+=("export I3PM_PWA_URL='$I3PM_PWA_URL'")
+    log "DEBUG" "Feature 113: Forwarding PWA URL for deep linking: $I3PM_PWA_URL"
+fi
+
 # Feature 101: All projects are now worktrees (using active-worktree.json as single source of truth)
 # I3PM_IS_WORKTREE is always true when we have an active worktree context
 if [[ -n "$WORKTREE_BRANCH" ]]; then


### PR DESCRIPTION
## Summary

- Add `tmux-url-open` script for extracting and opening URLs from terminal scrollback
- URLs matching PWA domains automatically open in the appropriate PWA
- Non-matching URLs open in Firefox

## Changes

### ghostty.nix
- Add `tmux-url-open` script with fzf integration
- Shows PWA indicators for each URL (🌐 = PWA, 🦊 = Firefox)
- Multi-select support for batch URL opening

### tmux.nix  
- Add `prefix+o` keybinding for URL opener popup

### pwa-launcher.nix
- Fix URL argument passing: use `--url` flag instead of `--` separator

### app-launcher-wrapper.sh
- Forward `I3PM_PWA_URL` environment variable for deep linking

## Test plan

- [ ] In tmux, run a command that outputs URLs (e.g., `gh pr list`)
- [ ] Press `prefix+o` to open URL picker
- [ ] Verify PWA indicators show correctly for known domains
- [ ] Select URL and verify it opens in correct app (PWA or Firefox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)