### PR TITLE
Add NixOS configurations for Lenovo and AMD devices

### DIFF
--- a/configurations/ryzen.nix
+++ b/configurations/ryzen.nix
@@ -1,0 +1,296 @@
+# AMD Ryzen Desktop Configuration
+# AMD Ryzen 5 7600X3D (Zen 4 with 3D V-Cache) - 6 cores, 4.1GHz base, 96MB L3
+# Physical desktop with Sway/Wayland desktop environment
+{ config, lib, pkgs, inputs, ... }:
+
+let
+  # Firefox 146+ overlay for native Wayland fractional scaling support
+  pkgs-unstable = import inputs.nixpkgs-bleeding {
+    system = pkgs.stdenv.hostPlatform.system;
+    config.allowUnfree = true;
+  };
+in
+{
+  imports = [
+    # Base configuration
+    ./base.nix
+
+    # Hardware
+    ../hardware/ryzen.nix
+
+    # nixos-hardware modules for AMD desktop
+    inputs.nixos-hardware.nixosModules.common-cpu-amd
+    inputs.nixos-hardware.nixosModules.common-cpu-amd-pstate
+    inputs.nixos-hardware.nixosModules.common-cpu-amd-zenpower
+    inputs.nixos-hardware.nixosModules.common-gpu-amd
+    inputs.nixos-hardware.nixosModules.common-pc
+    inputs.nixos-hardware.nixosModules.common-pc-ssd
+
+    # Desktop environment (Sway - Wayland compositor)
+    ../modules/desktop/sway.nix
+
+    # Services
+    ../modules/services/development.nix
+    ../modules/services/networking.nix
+    ../modules/services/onepassword.nix
+    ../modules/services/i3-project-daemon.nix
+    ../modules/services/speech-to-text-safe.nix
+
+    # Browser integrations with 1Password
+    ../modules/desktop/firefox-1password.nix
+  ];
+
+  # Firefox 146+ overlay for native Wayland fractional scaling support
+  nixpkgs.overlays = [
+    (final: prev: {
+      firefox = pkgs-unstable.firefox;
+      firefox-unwrapped = pkgs-unstable.firefox-unwrapped;
+    })
+  ];
+
+  # System identification
+  networking.hostName = "ryzen";
+
+  # Enable Sway Wayland compositor
+  services.sway.enable = true;
+
+  # i3 Project Management Daemon
+  services.i3ProjectDaemon = {
+    enable = true;
+    user = "vpittamp";
+    logLevel = "DEBUG";
+  };
+
+  # Display manager - greetd for Wayland/Sway login
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd sway";
+        user = "greeter";
+      };
+    };
+  };
+
+  # Speech-to-text service
+  services.speech-to-text = {
+    enable = true;
+    model = "base.en";
+    language = "en";
+    enableGlobalShortcut = true;
+    voskModelPackage = pkgs.callPackage ../pkgs/vosk-model-en-us-0.22-lgraph.nix { };
+  };
+
+  # wshowkeys setuid wrapper for workspace mode visual feedback
+  security.wrappers.wshowkeys = {
+    owner = "root";
+    group = "input";
+    setuid = true;
+    source = "${pkgs.wshowkeys}/bin/wshowkeys";
+  };
+
+  # Swap configuration - 16GB swap (desktop with 32GB RAM, no hibernation needed)
+  swapDevices = [
+    {
+      device = "/var/lib/swapfile";
+      size = 16384; # 16GB swap
+    }
+  ];
+
+  # Memory management tweaks for desktop workstation
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 10;
+    "vm.vfs_cache_pressure" = 50;
+    "vm.dirty_background_ratio" = 5;
+    "vm.dirty_ratio" = 10;
+    # Higher max memory map count for development workloads
+    "vm.max_map_count" = 1048576;
+  };
+
+  # Boot configuration for standard x86_64 UEFI
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 10;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Increase tmpfs size for kernel builds
+  boot.tmp.tmpfsSize = "75%";
+
+  # Kernel parameters for AMD Ryzen 7600X3D
+  boot.kernelParams = [
+    # AMD-specific
+    "amd_pstate=active"           # Use AMD P-State driver for Zen 4
+    # Performance settings for desktop
+    "mitigations=off"             # Optional: disable CPU mitigations for max performance
+                                  # Remove this line if security is priority
+  ];
+
+  # Fix intermittent home-manager activation failures during nixos-rebuild
+  systemd.services.home-manager-vpittamp = {
+    wants = [ "i3-project-daemon.socket" ];
+    after = [ "i3-project-daemon.socket" ];
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = "2s";
+      StartLimitBurst = 3;
+      StartLimitIntervalSec = 30;
+    };
+  };
+
+  # NetworkManager for ethernet (desktop)
+  networking.networkmanager = {
+    enable = true;
+  };
+
+  # Fonts - Nerd Fonts for SwayNC/Eww glyph icons
+  fonts = {
+    packages = let nerdFonts = pkgs."nerd-fonts"; in [
+      nerdFonts.jetbrains-mono
+      nerdFonts.fira-code
+      nerdFonts.ubuntu
+      nerdFonts.symbols-only
+    ];
+    fontconfig.defaultFonts = {
+      monospace = [ "JetBrainsMono Nerd Font Mono" ];
+      sansSerif = [ "Ubuntu Nerd Font" ];
+    };
+  };
+
+  # Display configuration for desktop
+  # Adjust DPI based on your monitor
+  services.xserver = {
+    dpi = 96;  # Standard DPI, adjust for your monitor
+
+    serverFlagsSection = ''
+      Option "DPI" "96 x 96"
+    '';
+
+    videoDrivers = [ "amdgpu" ];  # AMD GPU driver
+  };
+
+  # Display scaling configuration for Wayland
+  environment.sessionVariables = {
+    # Cursor size
+    XCURSOR_SIZE = "24";
+
+    # Java applications scaling
+    _JAVA_OPTIONS = "-Dsun.java2d.uiScale=1.0";
+
+    # Electron apps
+    ELECTRON_FORCE_IS_PACKAGED = "true";
+
+    # AMD Vulkan ICD (RADV for better performance in most cases)
+    AMD_VULKAN_ICD = "RADV";
+  };
+
+  # Platform configuration
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU configuration - performance for desktop
+  powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
+
+  # Hardware acceleration
+  hardware.graphics.enable = true;
+
+  # Firmware updates
+  hardware.enableRedistributableFirmware = true;
+
+  # Enable fwupd for firmware updates (LVFS)
+  services.fwupd.enable = true;
+
+  # Automatic garbage collection
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 7d";
+  };
+
+  # 1Password configuration
+  services.onepassword = {
+    enable = true;
+    user = "vpittamp";
+
+    gui.enable = true;
+
+    automation = {
+      enable = true;
+      tokenReference = "op://Employee/kzfqt6yulhj6glup3w22eupegu/credential";
+    };
+
+    passwordManagement = {
+      enable = false;
+      users.vpittamp = {
+        enable = true;
+        passwordReference = "op://CLI/NixOS User Password/password";
+      };
+      updateInterval = "hourly";
+    };
+
+    ssh.enable = true;
+  };
+
+  # Firefox with 1Password and PWA support
+  programs.firefox-1password = {
+    enable = true;
+    enablePWA = true;
+  };
+
+  # Fallback password for initial setup
+  users.users.vpittamp.initialPassword = lib.mkDefault "nixos";
+
+  # Add user to required groups
+  users.users.vpittamp.extraGroups = [ "wheel" "networkmanager" "video" "seat" "input" ];
+
+  # No battery-related services for desktop (no TLP, no UPower battery monitoring)
+
+  # Additional packages for desktop
+  environment.systemPackages = with pkgs; [
+    # Terminal
+    ghostty
+
+    # Firefox PWA support
+    firefoxpwa
+    imagemagick
+    librsvg
+
+    # Remote access
+    tailscale
+    remmina
+    wayvnc  # VNC server for Wayland remote access
+
+    # 1Password GUI
+    _1password-gui
+
+    # Hardware monitoring tools
+    lm_sensors     # Temperature monitoring
+    zenmonitor     # AMD Ryzen monitoring
+    corectrl       # AMD GPU/CPU control panel
+
+    # Hardware info
+    pciutils
+    usbutils
+    lshw
+  ];
+
+  # Firefox configuration with PWA support
+  programs.firefox = {
+    enable = lib.mkDefault true;
+    nativeMessagingHosts.packages = [ pkgs.firefoxpwa ];
+  };
+
+  # Tailscale VPN
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "client";
+    extraUpFlags = [ "--ssh" "--accept-routes" ];
+  };
+
+  # Firewall configuration
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 5900 ];  # SSH and VNC
+    checkReversePath = "loose";  # For Tailscale
+  };
+
+  # System state version
+  system.stateVersion = "25.11";
+}

--- a/configurations/thinkpad.nix
+++ b/configurations/thinkpad.nix
@@ -1,0 +1,376 @@
+# Lenovo ThinkPad Configuration
+# Intel Core Ultra 7 155U (Meteor Lake) with Intel Arc integrated graphics
+# Physical laptop with Sway/Wayland desktop environment
+{ config, lib, pkgs, inputs, ... }:
+
+let
+  # Firefox 146+ overlay for native Wayland fractional scaling support
+  pkgs-unstable = import inputs.nixpkgs-bleeding {
+    system = pkgs.stdenv.hostPlatform.system;
+    config.allowUnfree = true;
+  };
+in
+{
+  imports = [
+    # Base configuration
+    ./base.nix
+
+    # Hardware
+    ../hardware/thinkpad.nix
+
+    # nixos-hardware modules for Intel laptops
+    inputs.nixos-hardware.nixosModules.common-cpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-laptop
+    inputs.nixos-hardware.nixosModules.common-pc-laptop-ssd
+
+    # Desktop environment (Sway - Wayland compositor)
+    ../modules/desktop/sway.nix
+
+    # Services
+    ../modules/services/development.nix
+    ../modules/services/networking.nix
+    ../modules/services/onepassword.nix
+    ../modules/services/i3-project-daemon.nix
+    ../modules/services/speech-to-text-safe.nix
+
+    # Browser integrations with 1Password
+    ../modules/desktop/firefox-1password.nix
+  ];
+
+  # Firefox 146+ overlay for native Wayland fractional scaling support
+  nixpkgs.overlays = [
+    (final: prev: {
+      firefox = pkgs-unstable.firefox;
+      firefox-unwrapped = pkgs-unstable.firefox-unwrapped;
+    })
+  ];
+
+  # System identification
+  networking.hostName = "thinkpad";
+
+  # Enable Sway Wayland compositor
+  services.sway.enable = true;
+
+  # i3 Project Management Daemon
+  services.i3ProjectDaemon = {
+    enable = true;
+    user = "vpittamp";
+    logLevel = "DEBUG";
+  };
+
+  # Display manager - greetd for Wayland/Sway login
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd sway";
+        user = "greeter";
+      };
+    };
+  };
+
+  # Speech-to-text service
+  services.speech-to-text = {
+    enable = true;
+    model = "base.en";
+    language = "en";
+    enableGlobalShortcut = true;
+    voskModelPackage = pkgs.callPackage ../pkgs/vosk-model-en-us-0.22-lgraph.nix { };
+  };
+
+  # wshowkeys setuid wrapper for workspace mode visual feedback
+  security.wrappers.wshowkeys = {
+    owner = "root";
+    group = "input";
+    setuid = true;
+    source = "${pkgs.wshowkeys}/bin/wshowkeys";
+  };
+
+  # Swap configuration - 32GB swap for 32GB RAM (hibernation support)
+  swapDevices = [
+    {
+      device = "/var/lib/swapfile";
+      size = 32768; # 32GB swap for hibernation support
+    }
+  ];
+
+  # Memory management tweaks
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 10;
+    "vm.vfs_cache_pressure" = 50;
+    "vm.dirty_background_ratio" = 5;
+    "vm.dirty_ratio" = 10;
+  };
+
+  # Boot configuration for standard x86_64 UEFI
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 10;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  # Increase tmpfs size for kernel builds
+  boot.tmp.tmpfsSize = "75%";
+
+  # Kernel parameters for Intel Core Ultra (Meteor Lake)
+  boot.kernelParams = [
+    # Intel graphics tweaks for Meteor Lake
+    "i915.enable_psr=0"           # Disable Panel Self Refresh (can cause flickering)
+    "i915.enable_fbc=1"           # Enable framebuffer compression
+    # Power management
+    "intel_pstate=active"         # Use Intel P-state driver
+    # Meteor Lake specific
+    "i915.force_probe=*"          # Force probe for newer Intel GPUs if needed
+  ];
+
+  # Fix intermittent home-manager activation failures during nixos-rebuild
+  systemd.services.home-manager-vpittamp = {
+    wants = [ "i3-project-daemon.socket" ];
+    after = [ "i3-project-daemon.socket" ];
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = "2s";
+      StartLimitBurst = 3;
+      StartLimitIntervalSec = 30;
+    };
+  };
+
+  # NetworkManager for WiFi
+  networking.networkmanager = {
+    enable = true;
+    wifi.backend = "iwd";  # IWD is generally better on Intel WiFi
+  };
+
+  # Enable IWD for WiFi (better for Intel WiFi cards)
+  networking.wireless.iwd = {
+    enable = true;
+    settings = {
+      General = {
+        EnableNetworkConfiguration = true;
+      };
+      Settings = {
+        AutoConnect = true;
+      };
+    };
+  };
+
+  # Fonts - Nerd Fonts for SwayNC/Eww glyph icons
+  fonts = {
+    packages = let nerdFonts = pkgs."nerd-fonts"; in [
+      nerdFonts.jetbrains-mono
+      nerdFonts.fira-code
+      nerdFonts.ubuntu
+      nerdFonts.symbols-only
+    ];
+    fontconfig.defaultFonts = {
+      monospace = [ "JetBrainsMono Nerd Font Mono" ];
+      sansSerif = [ "Ubuntu Nerd Font" ];
+    };
+  };
+
+  # Display configuration
+  # ThinkPad display - adjust DPI based on actual panel resolution
+  services.xserver = {
+    dpi = 120;  # Adjust based on your panel
+
+    serverFlagsSection = ''
+      Option "DPI" "120 x 120"
+    '';
+
+    videoDrivers = [ "modesetting" ];  # Use modesetting for Intel Arc
+  };
+
+  # Display scaling configuration for Wayland
+  environment.sessionVariables = {
+    # Cursor size for HiDPI
+    XCURSOR_SIZE = "24";
+
+    # Java applications scaling
+    _JAVA_OPTIONS = "-Dsun.java2d.uiScale=1.0";
+
+    # Electron apps
+    ELECTRON_FORCE_IS_PACKAGED = "true";
+  };
+
+  # Touchpad configuration with natural scrolling (ThinkPad trackpad + TrackPoint)
+  services.libinput = {
+    enable = true;
+    touchpad = {
+      naturalScrolling = true;
+      tapping = true;
+      clickMethod = "clickfinger";
+      disableWhileTyping = true;
+      scrollMethod = "twofinger";
+      accelProfile = "adaptive";
+      accelSpeed = "0.0";
+    };
+  };
+
+  # Platform configuration
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU configuration
+  powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
+
+  # Hardware acceleration
+  hardware.graphics.enable = true;
+
+  # Firmware updates
+  hardware.enableRedistributableFirmware = true;
+
+  # Enable fwupd for firmware updates (LVFS)
+  services.fwupd.enable = true;
+
+  # Automatic garbage collection
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 7d";
+  };
+
+  # 1Password configuration
+  services.onepassword = {
+    enable = true;
+    user = "vpittamp";
+
+    gui.enable = true;
+
+    automation = {
+      enable = true;
+      tokenReference = "op://Employee/kzfqt6yulhj6glup3w22eupegu/credential";
+    };
+
+    passwordManagement = {
+      enable = false;
+      users.vpittamp = {
+        enable = true;
+        passwordReference = "op://CLI/NixOS User Password/password";
+      };
+      updateInterval = "hourly";
+    };
+
+    ssh.enable = true;
+  };
+
+  # Firefox with 1Password and PWA support
+  programs.firefox-1password = {
+    enable = true;
+    enablePWA = true;
+  };
+
+  # Fallback password for initial setup
+  users.users.vpittamp.initialPassword = lib.mkDefault "nixos";
+
+  # Add user to required groups
+  users.users.vpittamp.extraGroups = [ "wheel" "networkmanager" "video" "seat" "input" ];
+
+  # Bluetooth support (common in ThinkPads)
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+    settings = {
+      General = {
+        Enable = "Source,Sink,Media,Socket";
+        Experimental = true;
+      };
+    };
+  };
+
+  # Bluetooth manager GUI
+  services.blueman.enable = true;
+
+  # UPower for battery monitoring
+  services.upower.enable = true;
+
+  # TLP for better laptop power management
+  services.tlp = {
+    enable = true;
+    settings = {
+      CPU_SCALING_GOVERNOR_ON_AC = "performance";
+      CPU_SCALING_GOVERNOR_ON_BAT = "powersave";
+
+      CPU_ENERGY_PERF_POLICY_ON_AC = "performance";
+      CPU_ENERGY_PERF_POLICY_ON_BAT = "balance_power";
+
+      # Intel CPU specific
+      CPU_HWP_DYN_BOOST_ON_AC = 1;
+      CPU_HWP_DYN_BOOST_ON_BAT = 0;
+
+      # WiFi power saving
+      WIFI_PWR_ON_AC = "off";
+      WIFI_PWR_ON_BAT = "on";
+
+      # USB autosuspend
+      USB_AUTOSUSPEND = 1;
+
+      # Runtime PM for PCIe
+      RUNTIME_PM_ON_AC = "on";
+      RUNTIME_PM_ON_BAT = "auto";
+
+      # Battery charge thresholds (ThinkPad specific - uncomment if supported)
+      # START_CHARGE_THRESH_BAT0 = 75;
+      # STOP_CHARGE_THRESH_BAT0 = 80;
+    };
+  };
+
+  # Disable power-profiles-daemon (conflicts with TLP)
+  services.power-profiles-daemon.enable = false;
+
+  # Thermald for Intel thermal management
+  services.thermald.enable = true;
+
+  # Additional packages for laptop
+  environment.systemPackages = with pkgs; [
+    # Terminal
+    ghostty
+
+    # Brightness control
+    brightnessctl
+
+    # Firefox PWA support
+    firefoxpwa
+    imagemagick
+    librsvg
+
+    # Remote access
+    tailscale
+    remmina
+    wayvnc  # VNC server for Wayland remote access
+
+    # 1Password GUI
+    _1password-gui
+
+    # Power management utilities
+    powertop
+    acpi
+
+    # ThinkPad specific tools
+    tpacpi-bat  # ThinkPad ACPI battery control
+
+    # Hardware info
+    pciutils
+    usbutils
+    lshw
+  ];
+
+  # Firefox configuration with PWA support
+  programs.firefox = {
+    enable = lib.mkDefault true;
+    nativeMessagingHosts.packages = [ pkgs.firefoxpwa ];
+  };
+
+  # Tailscale VPN
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "client";
+    extraUpFlags = [ "--ssh" "--accept-routes" ];
+  };
+
+  # Firewall configuration
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 5900 ];  # SSH and VNC
+    checkReversePath = "loose";  # For Tailscale
+  };
+
+  # System state version
+  system.stateVersion = "25.11";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,10 @@
       url = "github:abenz1267/walker";
       inputs.elephant.follows = "elephant";
     };
+
+    # Hardware-specific NixOS modules
+    # Provides optimized configurations for various hardware platforms
+    nixos-hardware.url = "github:NixOS/nixos-hardware/master";
   };
 
   outputs = inputs @ { self, flake-parts, ... }:

--- a/hardware/ryzen.nix
+++ b/hardware/ryzen.nix
@@ -1,0 +1,88 @@
+# Hardware configuration for AMD Ryzen Desktop
+# AMD Ryzen 5 7600X3D (Zen 4 with 3D V-Cache) - 6 cores, 4.1GHz base, 96MB L3 cache
+# 32GB RAM
+#
+# Note: UUIDs need to be set after actual NixOS installation
+# Use 'blkid' to get the correct UUIDs from your installed system
+#
+# GPU Configuration:
+# - If using AMD GPU: This config includes AMD GPU support
+# - If using NVIDIA: Comment out AMD GPU section and enable NVIDIA in configuration file
+#
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  # Boot configuration for AMD Ryzen (Zen 4)
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"      # USB 3.0 host controller
+    "ahci"          # SATA AHCI controller
+    "nvme"          # NVMe SSD support
+    "usbhid"        # USB HID devices
+    "usb_storage"   # USB storage
+    "sd_mod"        # SATA/SCSI disk support
+  ];
+  boot.initrd.kernelModules = [ "amdgpu" ];  # Early load for AMD GPU
+  boot.kernelModules = [ "kvm-amd" ];
+  boot.extraModulePackages = [ ];
+
+  # File systems - PLACEHOLDER UUIDs (must be updated after installation)
+  # Run 'sudo blkid' after installation to get actual UUIDs
+  fileSystems."/" = {
+    device = "/dev/disk/by-uuid/PLACEHOLDER-ROOT-UUID";
+    fsType = "ext4";
+    options = [ "noatime" "nodiratime" ];
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/PLACEHOLDER-BOOT-UUID";
+    fsType = "vfat";
+    options = [ "fmask=0077" "dmask=0077" ];
+  };
+
+  # Swap - using swap file as configured in configurations/ryzen.nix
+  swapDevices = [ ];
+
+  # Platform configuration
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU configuration for AMD Ryzen 7600X3D
+  # Use performance governor for desktop (always plugged in)
+  powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
+
+  # AMD CPU microcode updates
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  # Hardware acceleration - AMD GPU (RDNA/RDNA2/RDNA3)
+  # If using NVIDIA, comment out this section and configure NVIDIA in the main config
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;  # For 32-bit application compatibility (Steam, Wine, etc.)
+
+    extraPackages = with pkgs; [
+      amdvlk                # AMD Vulkan driver
+      rocmPackages.clr.icd  # OpenCL support for AMD (ROCm)
+    ];
+
+    extraPackages32 = with pkgs.pkgsi686Linux; [
+      amdvlk
+    ];
+  };
+
+  # AMD GPU specific - use RADV (Mesa Vulkan) by default, can override to AMDVLK
+  environment.variables = {
+    # Use RADV by default (better performance in most cases)
+    # Set to "amdvlk" to use AMDVLK instead
+    AMD_VULKAN_ICD = "RADV";
+  };
+
+  # Firmware updates - essential for modern AMD hardware
+  hardware.enableRedistributableFirmware = true;
+
+  # Console font
+  console.earlySetup = true;
+  console.font = "Lat2-Terminus16";
+}

--- a/hardware/thinkpad.nix
+++ b/hardware/thinkpad.nix
@@ -1,0 +1,79 @@
+# Hardware configuration for Lenovo ThinkPad
+# Intel Core Ultra 7 155U (Meteor Lake) with Intel Arc integrated graphics
+# 32GB RAM
+#
+# Note: UUIDs need to be set after actual NixOS installation
+# Use 'blkid' to get the correct UUIDs from your installed system
+#
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  # Boot configuration for Intel Core Ultra (Meteor Lake)
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"      # USB 3.0/4.0 host controller
+    "thunderbolt"   # Thunderbolt/USB4 support
+    "nvme"          # NVMe SSD support
+    "usbhid"        # USB HID devices
+    "usb_storage"   # USB storage
+    "sd_mod"        # SATA/SCSI disk support
+    "rtsx_pci_sdmmc" # Realtek PCI SD card reader (common in ThinkPads)
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.extraModulePackages = [ ];
+
+  # File systems - PLACEHOLDER UUIDs (must be updated after installation)
+  # Run 'sudo blkid' after installation to get actual UUIDs
+  fileSystems."/" = {
+    device = "/dev/disk/by-uuid/PLACEHOLDER-ROOT-UUID";
+    fsType = "ext4";
+    options = [ "noatime" "nodiratime" ];
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/PLACEHOLDER-BOOT-UUID";
+    fsType = "vfat";
+    options = [ "fmask=0077" "dmask=0077" ];
+  };
+
+  # Swap - using swap file as configured in configurations/thinkpad.nix
+  swapDevices = [ ];
+
+  # Platform configuration
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # CPU configuration for Intel Core Ultra (Meteor Lake)
+  # Uses powersave by default for battery efficiency
+  powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
+
+  # Intel CPU microcode updates
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  # Hardware acceleration - Intel Arc graphics (Meteor Lake integrated)
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;  # For 32-bit application compatibility (Steam, Wine, etc.)
+
+    extraPackages = with pkgs; [
+      intel-media-driver    # VAAPI driver for Intel Gen 8+ (including Arc/Meteor Lake)
+      intel-compute-runtime # OpenCL support for Intel Arc
+      vpl-gpu-rt            # Intel Video Processing Library (QSV)
+      intel-ocl             # Additional OpenCL support
+    ];
+
+    extraPackages32 = with pkgs.pkgsi686Linux; [
+      intel-media-driver
+    ];
+  };
+
+  # Firmware updates - essential for Meteor Lake support
+  hardware.enableRedistributableFirmware = true;
+
+  # Console font for high-DPI display
+  console.earlySetup = true;
+  console.font = "Lat2-Terminus16";
+}

--- a/home-modules/ryzen.nix
+++ b/home-modules/ryzen.nix
@@ -1,0 +1,134 @@
+# Home-manager configuration for AMD Ryzen Desktop
+# Desktop with Sway, i3pm daemon, walker launcher
+{ pkgs, ... }:
+{
+  imports = [
+    # Base home configuration (shell, editors, tools)
+    ./profiles/base-home.nix
+
+    # Declarative cleanup (removes backups and stale files before activation)
+    ./profiles/declarative-cleanup.nix
+
+    # Desktop Environment: Sway (Wayland)
+    ./desktop/python-environment.nix
+    ./desktop/sway.nix
+    ./desktop/unified-bar-theme.nix
+    ./desktop/eww-workspace-bar.nix
+    ./desktop/eww-quick-panel.nix
+    ./desktop/eww-top-bar.nix
+    ./desktop/eww-monitoring-panel.nix
+    ./desktop/swaync.nix
+    ./desktop/sway-config-manager.nix
+
+    # Project management (works with Sway via IPC)
+    ./tools/i3pm-deno.nix
+    ./tools/i3pm-diagnostic.nix
+    ./tools/i3pm-workspace-mode-wrapper.nix
+
+    # Application launcher and registry
+    ./desktop/walker.nix
+    ./desktop/app-registry.nix
+    ./tools/app-launcher.nix
+    ./tools/pwa-launcher.nix
+
+    # Declarative PWA Installation
+    ./tools/firefox-pwas-declarative.nix
+    ./tools/pwa-helpers.nix
+  ];
+
+  home.username = "vpittamp";
+  home.homeDirectory = "/home/vpittamp";
+
+  # i3-msg → swaymsg compatibility symlink
+  home.file.".local/bin/i3-msg" = {
+    source = "${pkgs.sway}/bin/swaymsg";
+    executable = true;
+  };
+
+  # Sway Dynamic Configuration Management
+  programs.sway-config-manager = {
+    enable = true;
+    enableFileWatcher = true;
+    debounceMs = 500;
+  };
+
+  # Declarative PWA Installation
+  programs.firefoxpwa-declarative = {
+    enable = true;
+  };
+
+  # eww workspace bar with SVG icons
+  programs.eww-workspace-bar.enable = true;
+
+  # eww quick settings panel
+  programs.eww-quick-panel.enable = true;
+
+  # eww top bar with system metrics
+  programs.eww-top-bar.enable = true;
+
+  # eww monitoring panel
+  programs.eww-monitoring-panel.enable = true;
+
+  # sway-easyfocus - Keyboard-driven window hints
+  programs.sway-easyfocus = {
+    enable = true;
+    settings = {
+      # Hint characters (home row optimized)
+      chars = "fjghdkslaemuvitywoqpcbnxz";
+
+      # Catppuccin Mocha theme colors
+      window_background_color = "1e1e2e";
+      window_background_opacity = 0.3;
+      label_background_color = "313244";
+      label_text_color = "cdd6f4";
+      focused_background_color = "89b4fa";
+      focused_text_color = "1e1e2e";
+
+      # Font settings
+      font_family = "monospace";
+      font_weight = "bold";
+      font_size = "18pt";
+
+      # Spacing
+      label_padding_x = 8;
+      label_padding_y = 4;
+      label_margin_x = 4;
+      label_margin_y = 4;
+
+      # No confirmation window
+      show_confirmation = false;
+    };
+  };
+
+  # WayVNC configuration for remote access over Tailscale
+  # Desktop typically uses DP-1 or HDMI-A-1 - adjust based on your setup
+  xdg.configFile."wayvnc/config".text = ''
+    # WayVNC configuration for Ryzen Desktop
+    # Access via: vnc://<tailscale-ip>:5900 (Tailscale IP)
+    address=0.0.0.0
+    enable_auth=false
+  '';
+
+  # WayVNC systemd user service
+  # Note: Adjust output (-o flag) based on your monitor setup
+  # Common outputs: DP-1, HDMI-A-1, DP-2
+  # Run 'swaymsg -t get_outputs' to see available outputs
+  systemd.user.services.wayvnc = {
+    Unit = {
+      Description = "WayVNC - VNC server for Wayland (Ryzen Desktop)";
+      Documentation = "man:wayvnc(1)";
+      After = [ "sway-session.target" ];
+      BindsTo = [ "sway-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      # Using DP-1 as default - change to HDMI-A-1 or appropriate output
+      ExecStart = "${pkgs.wayvnc}/bin/wayvnc -o DP-1 0.0.0.0 5900";
+      Restart = "on-failure";
+      RestartSec = "3s";
+    };
+    Install = {
+      WantedBy = [ "sway-session.target" ];
+    };
+  };
+}

--- a/home-modules/thinkpad.nix
+++ b/home-modules/thinkpad.nix
@@ -1,0 +1,129 @@
+# Home-manager configuration for Lenovo ThinkPad
+# Physical laptop display with Sway, i3pm daemon, walker launcher
+{ pkgs, ... }:
+{
+  imports = [
+    # Base home configuration (shell, editors, tools)
+    ./profiles/base-home.nix
+
+    # Declarative cleanup (removes backups and stale files before activation)
+    ./profiles/declarative-cleanup.nix
+
+    # Desktop Environment: Sway (Wayland)
+    ./desktop/python-environment.nix
+    ./desktop/sway.nix
+    ./desktop/unified-bar-theme.nix
+    ./desktop/eww-workspace-bar.nix
+    ./desktop/eww-quick-panel.nix
+    ./desktop/eww-top-bar.nix
+    ./desktop/eww-monitoring-panel.nix
+    ./desktop/swaync.nix
+    ./desktop/sway-config-manager.nix
+
+    # Project management (works with Sway via IPC)
+    ./tools/i3pm-deno.nix
+    ./tools/i3pm-diagnostic.nix
+    ./tools/i3pm-workspace-mode-wrapper.nix
+
+    # Application launcher and registry
+    ./desktop/walker.nix
+    ./desktop/app-registry.nix
+    ./tools/app-launcher.nix
+    ./tools/pwa-launcher.nix
+
+    # Declarative PWA Installation
+    ./tools/firefox-pwas-declarative.nix
+    ./tools/pwa-helpers.nix
+  ];
+
+  home.username = "vpittamp";
+  home.homeDirectory = "/home/vpittamp";
+
+  # i3-msg → swaymsg compatibility symlink
+  home.file.".local/bin/i3-msg" = {
+    source = "${pkgs.sway}/bin/swaymsg";
+    executable = true;
+  };
+
+  # Sway Dynamic Configuration Management
+  programs.sway-config-manager = {
+    enable = true;
+    enableFileWatcher = true;
+    debounceMs = 500;
+  };
+
+  # Declarative PWA Installation
+  programs.firefoxpwa-declarative = {
+    enable = true;
+  };
+
+  # eww workspace bar with SVG icons
+  programs.eww-workspace-bar.enable = true;
+
+  # eww quick settings panel
+  programs.eww-quick-panel.enable = true;
+
+  # eww top bar with system metrics
+  programs.eww-top-bar.enable = true;
+
+  # eww monitoring panel
+  programs.eww-monitoring-panel.enable = true;
+
+  # sway-easyfocus - Keyboard-driven window hints
+  programs.sway-easyfocus = {
+    enable = true;
+    settings = {
+      # Hint characters (home row optimized)
+      chars = "fjghdkslaemuvitywoqpcbnxz";
+
+      # Catppuccin Mocha theme colors
+      window_background_color = "1e1e2e";
+      window_background_opacity = 0.3;
+      label_background_color = "313244";
+      label_text_color = "cdd6f4";
+      focused_background_color = "89b4fa";
+      focused_text_color = "1e1e2e";
+
+      # Font settings
+      font_family = "monospace";
+      font_weight = "bold";
+      font_size = "18pt";
+
+      # Spacing
+      label_padding_x = 8;
+      label_padding_y = 4;
+      label_margin_x = 4;
+      label_margin_y = 4;
+
+      # No confirmation window
+      show_confirmation = false;
+    };
+  };
+
+  # WayVNC configuration for remote access over Tailscale
+  xdg.configFile."wayvnc/config".text = ''
+    # WayVNC configuration for ThinkPad
+    # Access via: vnc://<tailscale-ip>:5900 (Tailscale IP)
+    address=0.0.0.0
+    enable_auth=false
+  '';
+
+  # WayVNC systemd user service
+  systemd.user.services.wayvnc = {
+    Unit = {
+      Description = "WayVNC - VNC server for Wayland (ThinkPad eDP-1)";
+      Documentation = "man:wayvnc(1)";
+      After = [ "sway-session.target" ];
+      BindsTo = [ "sway-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.wayvnc}/bin/wayvnc -o eDP-1 0.0.0.0 5900";
+      Restart = "on-failure";
+      RestartSec = "3s";
+    };
+    Install = {
+      WantedBy = [ "sway-session.target" ];
+    };
+  };
+}

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -80,6 +80,18 @@ let
       secondary = "HDMI-A-1";
       tertiary = "DP-1";  # USB-C/Thunderbolt display
     };
+    "thinkpad" = {
+      outputs = [ "eDP-1" "HDMI-A-1" "DP-1" ];
+      primary = "eDP-1";
+      secondary = "HDMI-A-1";
+      tertiary = "DP-1";  # USB-C/Thunderbolt display
+    };
+    "ryzen" = {
+      outputs = [ "DP-1" "HDMI-A-1" "DP-2" ];
+      primary = "DP-1";      # Primary monitor (adjust based on actual setup)
+      secondary = "HDMI-A-1";
+      tertiary = "DP-2";
+    };
   };
 in
 {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -63,6 +63,42 @@ in
     ];
   };
 
+  # Lenovo ThinkPad (Intel Core Ultra 7 155U + Intel Arc)
+  # Physical laptop with Sway/Wayland desktop
+  # Build: sudo nixos-rebuild switch --flake .#thinkpad
+  thinkpad = helpers.mkSystem {
+    hostname = "thinkpad";
+    system = "x86_64-linux";
+    modules = [
+      ../configurations/thinkpad.nix
+
+      # Home Manager integration with ThinkPad-specific config
+      (helpers.mkHomeManagerConfig {
+        system = "x86_64-linux";
+        user = "vpittamp";
+        modules = [ ../home-modules/thinkpad.nix ];
+      })
+    ];
+  };
+
+  # AMD Ryzen Desktop (AMD Ryzen 5 7600X3D + AMD GPU)
+  # Physical desktop with Sway/Wayland desktop
+  # Build: sudo nixos-rebuild switch --flake .#ryzen
+  ryzen = helpers.mkSystem {
+    hostname = "ryzen";
+    system = "x86_64-linux";
+    modules = [
+      ../configurations/ryzen.nix
+
+      # Home Manager integration with Ryzen-specific config
+      (helpers.mkHomeManagerConfig {
+        system = "x86_64-linux";
+        user = "vpittamp";
+        modules = [ ../home-modules/ryzen.nix ];
+      })
+    ];
+  };
+
   # ARCHIVED CONFIGURATIONS:
   # The following have been moved to archived/obsolete-configs/
   # - hetzner-i3.nix (testing config, consolidated into hetzner.nix)


### PR DESCRIPTION
Add two new device configurations that follow the same patterns as existing hetzner, m1, and acer configurations:

ThinkPad (Intel Core Ultra 7 155U):
- Hardware config with Meteor Lake support and Intel Arc graphics
- Uses nixos-hardware modules: common-cpu-intel, common-pc-laptop, common-pc-laptop-ssd
- Full Sway/Wayland desktop with i3pm, eww bars, walker launcher
- TLP power management for laptop battery optimization
- Intel WiFi via IWD backend
- Bluetooth support with blueman
- 32GB swap for hibernation support

AMD Ryzen Desktop (Ryzen 5 7600X3D):
- Hardware config for Zen 4 with 3D V-Cache (96MB L3)
- Uses nixos-hardware modules: common-cpu-amd, common-cpu-amd-pstate, common-cpu-amd-zenpower, common-gpu-amd, common-pc, common-pc-ssd
- AMD GPU support with RADV Vulkan driver
- Performance-oriented settings (no TLP, performance governor)
- ROCm OpenCL support
- zenmonitor and corectrl for hardware monitoring

Both configurations include:
- Full Sway/Wayland desktop environment
- i3pm project management daemon
- eww workspace/top/monitoring bars
- 1Password integration
- Firefox with PWA support
- Tailscale VPN
- WayVNC for remote access
- Speech-to-text service

Note: Hardware UUIDs in hardware/*.nix are placeholders and must be updated after actual NixOS installation using 'blkid'.