### PR TITLE
feat: Enable advanced hardware features for ThinkPad and Ryzen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1217,6 +1217,8 @@ gh auth status               # Auto-uses 1Password token
 - JSON files (`~/.config/i3/projects/*.json`), in-memory daemon state (109-enhance-worktree-user-experience)
 - Python 3.11+ (streaming backend, matching Constitution Principle X), Yuck/GTK CSS (Eww widgets) + SwayNC (swaync-client --subscribe), Eww 0.4+ (deflisten), Python subprocess for event streaming (110-improve-notifications-system)
 - N/A (stateless - SwayNC is the source of truth) (110-improve-notifications-system)
+- Nix (NixOS 25.11), Bash 5.0+ for helper scripts + nixos-hardware modules, home-manager, PipeWire, Firefox, NVIDIA drivers, Intel media-driver (115-enable-advanced-hardware-features)
+- N/A (configuration management, no data storage) (115-enable-advanced-hardware-features)
 
 ## Recent Changes
 - 109-enhance-worktree-user-experience: Branch number badges with gradient styling (mauve/pink for numbered, blue for main, green for feature), icon alignment fixes, hover transition improvements

--- a/configurations/ryzen.nix
+++ b/configurations/ryzen.nix
@@ -374,6 +374,16 @@ in
 
     # USB device management
     udiskie        # Automount USB drives
+
+    # ========== SCREEN RECORDING (Feature 115) ==========
+    # Hardware-accelerated screen recording with NVIDIA NVENC
+    wf-recorder       # Wayland screen recorder with NVENC support
+    grim              # Screenshot utility for Wayland
+    slurp             # Region selection for screenshots/recording
+
+    # ========== WEBCAM SUPPORT (Feature 115) ==========
+    # V4L2 support for USB webcams
+    v4l-utils         # Video4Linux utilities
   ];
 
   # Firefox configuration with PWA support

--- a/configurations/thinkpad.nix
+++ b/configurations/thinkpad.nix
@@ -230,6 +230,13 @@ in
 
     # Electron apps
     ELECTRON_FORCE_IS_PACKAGED = "true";
+
+    # ========== VA-API HARDWARE VIDEO ACCELERATION ==========
+    # Intel Arc (Meteor Lake) uses the iHD VA-API driver
+    LIBVA_DRIVER_NAME = "iHD";
+
+    # Enable Wayland for Electron apps
+    NIXOS_OZONE_WL = "1";
   };
 
   # Touchpad configuration with natural scrolling (ThinkPad trackpad + TrackPoint)
@@ -260,6 +267,11 @@ in
 
   # Enable fwupd for firmware updates (LVFS)
   services.fwupd.enable = true;
+
+  # ========== THUNDERBOLT/USB4 SUPPORT (Feature 115) ==========
+  # Enable bolt daemon for Thunderbolt device authorization
+  # Allows docking stations and external displays via Thunderbolt
+  services.hardware.bolt.enable = true;
 
   # Fingerprint reader support (Elan 04f3:0c8c MOC Sensor)
   # Enroll fingerprint with: fprintd-enroll
@@ -461,6 +473,12 @@ in
     # Webcam (if present)
     v4l-utils         # Video4Linux utilities
     cameractrls       # Webcam controls
+
+    # ========== SCREEN RECORDING (Feature 115) ==========
+    # Hardware-accelerated screen recording with Intel QuickSync
+    wf-recorder       # Wayland screen recorder with VAAPI support
+    grim              # Screenshot utility for Wayland
+    slurp             # Region selection for screenshots/recording
   ];
 
   # Firefox configuration with PWA support

--- a/specs/115-enable-advanced-hardware-features/checklists/requirements.md
+++ b/specs/115-enable-advanced-hardware-features/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Enable Advanced Hardware Features
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Key scope boundaries established:
+  - ThinkPad (Intel Core Ultra 7 155U / Intel Arc) and Ryzen (AMD 7600X3D / NVIDIA RTX 5070) are in scope
+  - Hetzner VM remains unchanged (software rendering)
+  - M1 is deprecated and not in scope
+  - HDR/color management deferred (Sway support immature)
+  - Intel NPU deferred (not packaged in NixOS)
+  - Gaming features not in scope (already disabled)

--- a/specs/115-enable-advanced-hardware-features/contracts/README.md
+++ b/specs/115-enable-advanced-hardware-features/contracts/README.md
@@ -1,0 +1,63 @@
+# Contracts: Enable Advanced Hardware Features
+
+**Feature**: 115-enable-advanced-hardware-features
+**Date**: 2025-12-13
+
+## Not Applicable
+
+This feature involves NixOS configuration changes rather than API development. Therefore, traditional API contracts (OpenAPI, GraphQL schemas) are not applicable.
+
+## Equivalent Contracts
+
+For NixOS configurations, the equivalent of "contracts" are:
+
+### 1. NixOS Option Types
+
+The NixOS module system enforces type contracts via option declarations:
+
+```nix
+# Example from modules/services/bare-metal.nix
+options.services.bare-metal = {
+  enable = mkEnableOption "bare-metal optimizations";
+
+  enableVirtualization = mkOption {
+    type = types.bool;
+    default = true;
+    description = "Enable KVM virtualization";
+  };
+};
+```
+
+### 2. Build-Time Validation
+
+Configuration contracts are validated at build time:
+
+```bash
+# Dry-build validates all configuration options
+nixos-rebuild dry-build --flake .#thinkpad
+```
+
+### 3. Hardware Detection
+
+Runtime hardware availability is detected via conditional logic:
+
+```nix
+# Conditional package installation based on hardware
+environment.systemPackages = lib.optionals (config.hardware.nvidia.enable) [
+  pkgs.nvtopPackages.nvidia
+];
+```
+
+## Verification Commands
+
+Instead of API contracts, this feature provides verification commands to validate hardware functionality:
+
+| Feature | Verification Command | Expected Output |
+|---------|---------------------|-----------------|
+| VA-API | `vainfo` | Lists decoder/encoder profiles |
+| NVIDIA | `nvidia-smi` | Shows GPU status |
+| Bluetooth | `bluetoothctl devices` | Lists paired devices |
+| Webcam | `v4l2-ctl --list-devices` | Shows /dev/videoN |
+| Audio | `pw-top` | Shows audio streams |
+
+See `quickstart.md` for complete verification procedures.

--- a/specs/115-enable-advanced-hardware-features/data-model.md
+++ b/specs/115-enable-advanced-hardware-features/data-model.md
@@ -1,0 +1,294 @@
+# Data Model: Enable Advanced Hardware Features
+
+**Feature**: 115-enable-advanced-hardware-features
+**Date**: 2025-12-13
+
+## Overview
+
+This feature involves NixOS configuration changes, not traditional application data models. This document describes the configuration entities, their relationships, and validation rules.
+
+---
+
+## Configuration Entities
+
+### 1. Hardware Profile
+
+Represents platform-specific hardware configuration.
+
+**Entity**: `hardware/<platform>.nix`
+
+| Field | Type | Description | Validation |
+|-------|------|-------------|------------|
+| `platform` | string | Hardware platform identifier | `thinkpad`, `ryzen` |
+| `graphics.enable` | bool | Enable hardware graphics | Required `true` for GPU acceleration |
+| `graphics.enable32Bit` | bool | Enable 32-bit graphics support | Optional, for Wine/Steam |
+| `graphics.extraPackages` | list[package] | GPU-specific packages | Platform-dependent |
+| `cpu.updateMicrocode` | bool | Enable CPU microcode updates | Recommended `true` |
+
+**ThinkPad-Specific Fields**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `graphics.extraPackages` | list | `intel-media-driver`, `intel-compute-runtime`, `vpl-gpu-rt` |
+
+**Ryzen-Specific Fields**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `nvidia.package` | package | NVIDIA driver package |
+| `nvidia.modesetting.enable` | bool | DRM modesetting for Wayland |
+| `nvidia.open` | bool | Use open-source kernel modules |
+
+---
+
+### 2. Target Configuration
+
+Represents complete system configuration for a deployment target.
+
+**Entity**: `configurations/<target>.nix`
+
+| Field | Type | Description | Validation |
+|-------|------|-------------|------------|
+| `hostName` | string | System hostname | Required |
+| `services.pipewire` | attrset | Audio configuration | See PipeWire section |
+| `services.bare-metal` | attrset | Bare metal features | See Bare Metal section |
+| `hardware.bluetooth` | attrset | Bluetooth configuration | Optional (laptop only) |
+| `environment.sessionVariables` | attrset | Environment variables | Platform-specific |
+
+---
+
+### 3. PipeWire Configuration
+
+Audio pipeline configuration with low-latency and codec support.
+
+**Entity**: `services.pipewire` (NixOS option)
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `enable` | bool | Enable PipeWire | `true` |
+| `alsa.enable` | bool | ALSA compatibility | `true` |
+| `pulse.enable` | bool | PulseAudio compatibility | `true` |
+| `jack.enable` | bool | JACK compatibility | `true` |
+| `extraConfig.pipewire."92-low-latency".context.properties."default.clock.quantum"` | int | Buffer size | `256` |
+| `extraConfig.pipewire."92-low-latency".context.properties."default.clock.rate"` | int | Sample rate | `48000` |
+| `wireplumber.extraConfig."10-bluez".monitor.bluez.properties.bluez5.codecs` | list[string] | Bluetooth codecs | See below |
+
+**Bluetooth Codec Priority** (WirePlumber):
+```
+["sbc", "sbc_xq", "aac", "ldac", "aptx", "aptx_hd"]
+```
+
+---
+
+### 4. Bare Metal Features
+
+Hardware-specific features not available on VMs.
+
+**Entity**: `services.bare-metal` (custom NixOS option)
+
+| Field | Type | Description | ThinkPad | Ryzen |
+|-------|------|-------------|----------|-------|
+| `enable` | bool | Enable module | `true` | `true` |
+| `enableVirtualization` | bool | KVM/libvirt | `true` | `true` |
+| `enablePodman` | bool | Container runtime | `true` | `true` |
+| `enablePrinting` | bool | CUPS printing | `true` | `true` |
+| `enableFingerprint` | bool | Fingerprint auth | `true` | `false` |
+| `enableGaming` | bool | Steam/GameMode | `false` | `false` |
+| `enableScanning` | bool | SANE scanner | `false` | `false` |
+
+---
+
+### 5. Firefox Hardware Acceleration
+
+Browser settings for hardware video decoding.
+
+**Entity**: `programs.firefox.profiles.<name>.settings` (home-manager option)
+
+| Setting | Type | Description | Value |
+|---------|------|-------------|-------|
+| `media.ffmpeg.vaapi.enabled` | bool | Enable VA-API decode | `true` |
+| `media.hardware-video-decoding.force-enabled` | bool | Force HW decode | `true` |
+| `media.av1.enabled` | bool | Enable AV1 codec | `true` |
+| `gfx.webrender.all` | bool | GPU WebRender | `true` |
+
+---
+
+### 6. Environment Variables
+
+Platform-specific environment configuration.
+
+**Entity**: `environment.sessionVariables` (NixOS option)
+
+**Intel (ThinkPad)**:
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `LIBVA_DRIVER_NAME` | `iHD` | VA-API backend |
+| `MOZ_ENABLE_WAYLAND` | `1` | Firefox Wayland |
+
+**NVIDIA (Ryzen)**:
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `LIBVA_DRIVER_NAME` | `nvidia` | VA-API via NVIDIA |
+| `GBM_BACKEND` | `nvidia-drm` | GBM backend |
+| `__GLX_VENDOR_LIBRARY_NAME` | `nvidia` | GLX vendor |
+| `WLR_NO_HARDWARE_CURSORS` | `1` | Cursor workaround |
+| `NIXOS_OZONE_WL` | `1` | Electron Wayland |
+
+---
+
+## Relationships
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Target Configuration                       │
+│               (configurations/thinkpad.nix)                   │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  ┌─────────────────┐    ┌─────────────────┐                  │
+│  │ Hardware Profile │    │ nixos-hardware  │                  │
+│  │ (hardware/*.nix) │    │    modules      │                  │
+│  └────────┬────────┘    └────────┬────────┘                  │
+│           │                      │                            │
+│           └──────────┬───────────┘                            │
+│                      ▼                                        │
+│  ┌─────────────────────────────────────────┐                 │
+│  │          Hardware Graphics              │                 │
+│  │  • GPU drivers (intel-media/nvidia)     │                 │
+│  │  • VA-API packages                       │                 │
+│  │  • OpenCL runtime                        │                 │
+│  └─────────────────────────────────────────┘                 │
+│                                                               │
+│  ┌─────────────────┐    ┌─────────────────┐                  │
+│  │    PipeWire     │    │   Bluetooth     │                  │
+│  │  • Low latency  │    │  • Codecs       │                  │
+│  │  • JACK bridge  │    │  • WirePlumber  │                  │
+│  └─────────────────┘    └─────────────────┘                  │
+│                                                               │
+│  ┌─────────────────┐    ┌─────────────────┐                  │
+│  │  Bare Metal     │    │   Environment   │                  │
+│  │  • TPM          │    │   Variables     │                  │
+│  │  • Thunderbolt  │    │  • VA-API       │                  │
+│  │  • Fingerprint  │    │  • Wayland      │                  │
+│  └─────────────────┘    └─────────────────┘                  │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Home Manager                               │
+│                (home-vpittamp.nix)                            │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  ┌─────────────────────────────────────────┐                 │
+│  │           Firefox Settings              │                 │
+│  │  • media.ffmpeg.vaapi.enabled           │                 │
+│  │  • gfx.webrender.all                    │                 │
+│  └─────────────────────────────────────────┘                 │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## State Transitions
+
+### Video Playback State (Firefox)
+
+```
+┌──────────────┐     Browser Start     ┌──────────────────┐
+│   Disabled   │ ────────────────────► │  Software Decode │
+│              │                       │   (CPU 60%+)     │
+└──────────────┘                       └────────┬─────────┘
+                                                │
+                                    VA-API Available?
+                                                │
+                           ┌────────────────────┴────────────────────┐
+                           │ Yes                                     │ No
+                           ▼                                         ▼
+                 ┌──────────────────┐                     ┌──────────────────┐
+                 │  Hardware Decode │                     │  Software Decode │
+                 │   (CPU <20%)     │                     │   (CPU 60%+)     │
+                 └──────────────────┘                     └──────────────────┘
+```
+
+### Bluetooth Audio Codec Negotiation
+
+```
+┌──────────────┐   Device Connected   ┌──────────────────┐
+│  Bluetooth   │ ────────────────────►│ Codec Negotiation│
+│  Pairing     │                      │                  │
+└──────────────┘                      └────────┬─────────┘
+                                               │
+                                   Device Capabilities
+                                               │
+      ┌────────────┬────────────┬────────────┬─┴──────────┬──────────┐
+      │ LDAC       │ aptX HD    │ aptX       │ AAC        │ SBC      │
+      ▼            ▼            ▼            ▼            ▼          │
+  ┌────────┐  ┌────────┐   ┌────────┐   ┌────────┐   ┌────────┐     │
+  │ 990kbps│  │ 576kbps│   │ 352kbps│   │ 256kbps│   │ 328kbps│     │
+  │ HQ     │  │ HD     │   │ Standard│  │ Standard│  │ Fallback│◄────┘
+  └────────┘  └────────┘   └────────┘   └────────┘   └────────┘
+      ▲
+      └── Preferred (highest quality available)
+```
+
+---
+
+## Validation Rules
+
+### Configuration Build Validation
+
+| Rule | Validation | Error |
+|------|------------|-------|
+| Hardware profile exists | `hardware/<platform>.nix` exists | Build fails with missing import |
+| Graphics packages valid | All packages in extraPackages exist | Build fails with undefined |
+| NVIDIA driver compatible | Package matches kernel | Build fails with version mismatch |
+| Environment variables set | Required env vars defined | Runtime: VA-API unavailable |
+
+### Runtime Validation
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| VA-API available | `vainfo` | Lists decode/encode profiles |
+| GPU rendering | `glxinfo \| grep renderer` | Shows GPU name |
+| Bluetooth codec | `pactl list sinks` | Shows LDAC/aptX codec |
+| Webcam detected | `v4l2-ctl --list-devices` | Lists /dev/video* |
+| Audio latency | `pw-top` | Quantum ~256 samples |
+
+---
+
+## Package Requirements by Platform
+
+### ThinkPad (Intel Arc)
+
+```nix
+environment.systemPackages = [
+  intel-gpu-tools    # GPU monitoring (intel_gpu_top)
+  libva-utils        # VA-API verification (vainfo)
+  vdpauinfo          # VDPAU verification
+  v4l-utils          # Webcam utilities
+  cameractrls        # Camera controls
+  wf-recorder        # Screen recording
+];
+```
+
+### Ryzen (NVIDIA RTX 5070)
+
+```nix
+environment.systemPackages = [
+  nvtopPackages.nvidia  # GPU monitoring TUI
+  libva-utils           # VA-API verification
+  vulkan-tools          # Vulkan verification
+  clinfo                # OpenCL verification
+  cudaPackages.cuda_nvcc # CUDA compiler
+  wf-recorder           # Screen recording
+];
+```
+
+### Shared (Both Platforms)
+
+```nix
+environment.systemPackages = [
+  grim                  # Screenshots
+  slurp                 # Region selection
+  wl-clipboard          # Clipboard utilities
+];
+```

--- a/specs/115-enable-advanced-hardware-features/plan.md
+++ b/specs/115-enable-advanced-hardware-features/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Enable Advanced Hardware Features
+
+**Branch**: `115-enable-advanced-hardware-features` | **Date**: 2025-12-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/115-enable-advanced-hardware-features/spec.md`
+
+## Summary
+
+Enable advanced hardware features on ThinkPad (Intel Core Ultra 7 155U / Intel Arc) and Ryzen desktop (AMD 7600X3D / NVIDIA RTX 5070) that were previously unavailable on Hetzner VM. Primary enhancements: GPU-accelerated video decoding in Firefox/PWAs (VA-API/NVDEC), webcam V4L2 support, Bluetooth high-quality audio codecs (LDAC/aptX), hardware screen recording (QuickSync/NVENC), Thunderbolt/USB4 dock support, CUDA/OpenCL compute, low-latency PipeWire audio, and GPU-accelerated Sway compositor rendering.
+
+## Technical Context
+
+**Language/Version**: Nix (NixOS 25.11), Bash 5.0+ for helper scripts
+**Primary Dependencies**: nixos-hardware modules, home-manager, PipeWire, Firefox, NVIDIA drivers, Intel media-driver
+**Storage**: N/A (configuration management, no data storage)
+**Testing**: `nixos-rebuild dry-build` for configuration validation, manual hardware verification
+**Target Platform**: NixOS on x86_64 bare metal (ThinkPad Intel, Ryzen AMD/NVIDIA)
+**Project Type**: NixOS configuration modules (single project - flake-based)
+**Performance Goals**: <20% CPU for 1080p video playback, <15ms audio latency, 60fps compositor
+**Constraints**: Must not break Hetzner VM configuration, must support conditional hardware detection
+**Scale/Scope**: 2 target configurations (thinkpad, ryzen), ~10 module files affected
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Modular Composition | ✅ PASS | Hardware features added via existing modules (`hardware/*.nix`, `configurations/*.nix`) |
+| II. Reference Implementation | ✅ PASS | Hetzner remains reference; ThinkPad/Ryzen are platform-specific enhancements |
+| III. Test-Before-Apply | ✅ PASS | All changes will be validated via `nixos-rebuild dry-build` |
+| IV. Override Priority | ✅ PASS | Use `lib.mkDefault` for overrideable GPU settings, `lib.mkIf` for conditional hardware |
+| V. Platform Flexibility | ✅ PASS | Conditional features detect hardware (Intel vs NVIDIA, laptop vs desktop) |
+| VI. Declarative Configuration | ✅ PASS | All settings in Nix expressions, no imperative scripts |
+| VII. Documentation as Code | ✅ PASS | CLAUDE.md will be updated with hardware verification commands |
+| X. Python Standards | ⚠️ N/A | No Python code in this feature |
+| XI. i3 IPC Alignment | ⚠️ N/A | No daemon changes in this feature |
+| XII. Forward-Only | ✅ PASS | No backwards compatibility needed - new features on new hardware |
+| XIII. Deno CLI Standards | ⚠️ N/A | No CLI tools in this feature |
+| XIV. Test-Driven | ⚠️ PARTIAL | Hardware testing requires manual verification; dry-build covers config |
+| XV. Sway Test Framework | ⚠️ N/A | No window management logic changes |
+
+**Gate Result**: ✅ PASS - No constitutional violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/115-enable-advanced-hardware-features/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output - hardware research
+├── data-model.md        # Phase 1 output - configuration model
+├── quickstart.md        # Phase 1 output - verification guide
+├── contracts/           # Phase 1 output - N/A for NixOS config
+│   └── README.md        # Explanation of why contracts not applicable
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+# NixOS Configuration Structure (existing layout)
+configurations/
+├── thinkpad.nix         # MODIFY: Intel Arc GPU, webcam, Bluetooth, Thunderbolt
+├── ryzen.nix            # MODIFY: NVIDIA NVENC/NVDEC, CUDA, OpenCL
+├── base.nix             # NO CHANGE: Base configuration
+└── hetzner-sway.nix     # NO CHANGE: Reference configuration (software rendering)
+
+hardware/
+├── thinkpad.nix         # MODIFY: Intel graphics packages, VA-API
+└── ryzen.nix            # MODIFY: NVIDIA kernel params, DRM
+
+modules/
+├── services/
+│   └── bare-metal.nix   # REVIEW: May need webcam/V4L2 additions
+└── desktop/
+    └── sway.nix         # REVIEW: Hardware cursor, DRM/KMS settings
+
+home-modules/
+└── tools/
+    └── firefox.nix      # MODIFY: Hardware video decoding settings
+```
+
+**Structure Decision**: Existing NixOS flake structure is preserved. Changes are distributed across hardware configs, target configs, and home-manager modules. No new directories needed.
+
+## Complexity Tracking
+
+> No violations requiring justification. This feature adds hardware-specific configurations within existing module structure.
+
+| Area | Complexity Level | Justification |
+|------|------------------|---------------|
+| Intel graphics | Low | Standard nixos-hardware modules + packages |
+| NVIDIA Wayland | Medium | NVIDIA on Wayland requires specific env vars and kernel params |
+| Bluetooth codecs | Low | WirePlumber configuration in existing PipeWire setup |
+| Webcam V4L2 | Low | Package additions + udev rules |
+| CUDA/OpenCL | Medium | Package additions, may need cudaPackages overlay |
+| Thunderbolt | Low | Bolt daemon + kernel modules (already in hardware config) |
+
+## Implementation Phases
+
+### Phase 0: Research (Complete)
+
+See `research.md` for detailed findings on:
+- Intel Arc VA-API configuration (intel-media-driver, vpl-gpu-rt)
+- NVIDIA NVDEC/NVENC for Firefox hardware video decoding
+- Bluetooth codec priorities (LDAC > aptX HD > aptX > AAC > SBC)
+- V4L2 webcam enumeration and permissions
+- Hardware screen recording tools (wf-recorder with VA-API/NVENC)
+- Thunderbolt bolt daemon configuration
+- PipeWire low-latency quantum settings
+
+### Phase 1: Design
+
+See `data-model.md` for configuration structure and `quickstart.md` for verification commands.
+
+### Phase 2: Tasks
+
+Generated by `/speckit.tasks` command - not included in this plan.

--- a/specs/115-enable-advanced-hardware-features/quickstart.md
+++ b/specs/115-enable-advanced-hardware-features/quickstart.md
@@ -1,0 +1,346 @@
+# Quickstart: Enable Advanced Hardware Features
+
+**Feature**: 115-enable-advanced-hardware-features
+**Date**: 2025-12-13
+
+## Overview
+
+This guide provides verification commands and troubleshooting steps for advanced hardware features on ThinkPad (Intel Arc) and Ryzen (NVIDIA RTX 5070) systems.
+
+---
+
+## Build & Apply Configuration
+
+### Step 1: Dry Build (Required)
+
+```bash
+# ThinkPad
+sudo nixos-rebuild dry-build --flake .#thinkpad
+
+# Ryzen
+sudo nixos-rebuild dry-build --flake .#ryzen
+```
+
+### Step 2: Apply Configuration
+
+```bash
+# ThinkPad
+sudo nixos-rebuild switch --flake .#thinkpad
+
+# Ryzen
+sudo nixos-rebuild switch --flake .#ryzen
+```
+
+---
+
+## Feature Verification
+
+### 1. GPU Hardware Acceleration
+
+**Intel (ThinkPad)**:
+```bash
+# Check VA-API driver
+vainfo
+# Expected: VAProfileH264*, VAProfileHEVC*, VAEntrypointEncSlice
+
+# Monitor GPU usage
+intel_gpu_top
+# Expected: Shows Video, Render, Blitter engines
+
+# Check OpenCL
+clinfo | head -20
+# Expected: Platform: Intel(R) OpenCL Graphics
+```
+
+**NVIDIA (Ryzen)**:
+```bash
+# Check NVIDIA driver
+nvidia-smi
+# Expected: Shows RTX 5070, driver version
+
+# Check VA-API via NVIDIA
+vainfo
+# Expected: VAProfileH264*, VAProfileHEVC*
+
+# Monitor GPU usage
+nvtop
+# Expected: Interactive GPU monitoring
+
+# Check Vulkan
+vulkaninfo | grep -i "gpu"
+# Expected: GeForce RTX 5070
+```
+
+---
+
+### 2. Firefox Hardware Video Decoding
+
+**Verification Steps**:
+
+1. Open Firefox
+2. Navigate to `about:support`
+3. Look for "Hardware Video Decoding": **ENABLED**
+4. Play a YouTube video (1080p60 or 4K)
+5. Monitor GPU:
+   - Intel: `intel_gpu_top` - Video engine shows activity
+   - NVIDIA: `nvidia-smi dmon` - Dec column shows activity
+6. Monitor CPU: Should be <20% during playback
+
+**Troubleshooting**:
+```bash
+# Check environment variable
+echo $LIBVA_DRIVER_NAME
+# Expected: "iHD" (Intel) or "nvidia" (NVIDIA)
+
+# Check Firefox Wayland
+echo $MOZ_ENABLE_WAYLAND
+# Expected: "1"
+```
+
+---
+
+### 3. Webcam (V4L2)
+
+```bash
+# List video devices
+v4l2-ctl --list-devices
+# Expected: Shows /dev/video0, /dev/video1, etc.
+
+# Show camera capabilities
+v4l2-ctl -d /dev/video0 --all
+# Expected: Shows resolution, formats, controls
+
+# Test camera (optional)
+ffplay /dev/video0
+# Expected: Live camera preview
+
+# Camera controls
+cameractrls -d /dev/video0 --list-ctrls
+# Expected: Lists brightness, contrast, etc.
+```
+
+**Browser Test**:
+1. Open Firefox
+2. Navigate to https://meet.google.com (or any video call site)
+3. Check camera settings - webcam should be listed
+4. Enable camera - video should appear
+
+---
+
+### 4. Bluetooth Audio (ThinkPad)
+
+```bash
+# List paired devices
+bluetoothctl devices
+# Expected: Lists paired Bluetooth devices
+
+# Check device info (replace MAC)
+bluetoothctl info XX:XX:XX:XX:XX:XX
+# Expected: Shows codec capabilities
+
+# Check active audio sink
+pactl list sinks | grep -A5 "bluez"
+# Expected: Shows codec (LDAC, aptX, AAC, or SBC)
+
+# Check PipeWire Bluetooth
+pw-top
+# Expected: Shows Bluetooth audio stream with codec info
+```
+
+**Codec Priority Verification**:
+1. Pair high-quality headphones (Sony WH-1000XM, etc.)
+2. Play audio
+3. Check codec: `pactl list sinks | grep -i codec`
+4. Expected: LDAC (990kbps) if device supports it
+
+---
+
+### 5. Hardware Screen Recording
+
+**wf-recorder with Hardware Encoding**:
+
+```bash
+# Intel (VAAPI)
+wf-recorder -c h264_vaapi -f recording.mp4
+
+# NVIDIA (NVENC)
+wf-recorder -c h264_nvenc -f recording.mp4
+
+# Record specific output
+wf-recorder -o eDP-1 -f recording.mp4
+
+# Record region
+wf-recorder -g "$(slurp)" -f recording.mp4
+```
+
+**Verification**:
+1. Start recording with hardware encoder
+2. Monitor CPU usage: Should be <30% for 1080p60
+3. Check encoder usage:
+   - Intel: `intel_gpu_top` - Video engine active
+   - NVIDIA: `nvidia-smi dmon` - Enc column active
+
+---
+
+### 6. PipeWire Low-Latency Audio
+
+```bash
+# Check PipeWire status
+systemctl --user status pipewire pipewire-pulse wireplumber
+
+# Check audio configuration
+pw-top
+# Expected: Quantum ~256, Rate 48000
+
+# Check latency
+pw-profiler
+# Expected: <15ms round-trip latency
+
+# List audio devices
+pactl list sinks short
+pactl list sources short
+```
+
+**JACK Applications**:
+```bash
+# Verify JACK bridge
+pw-jack jack_lsp
+# Expected: Lists JACK ports through PipeWire
+```
+
+---
+
+### 7. Thunderbolt/USB4 (ThinkPad)
+
+```bash
+# List Thunderbolt devices
+boltctl list
+# Expected: Lists connected Thunderbolt devices
+
+# Check device authorization
+boltctl info <UUID>
+# Expected: Shows authorization status
+
+# Authorize device (if needed)
+boltctl authorize <UUID>
+```
+
+**Dock Verification**:
+1. Connect Thunderbolt dock
+2. Check outputs: `swaymsg -t get_outputs`
+3. Check USB: `lsusb`
+4. Check network (if dock has Ethernet): `ip link`
+
+---
+
+### 8. CUDA/OpenCL (Ryzen)
+
+```bash
+# Check CUDA compiler
+nvcc --version
+# Expected: CUDA 12.x
+
+# Check OpenCL platforms
+clinfo
+# Expected: Platform: NVIDIA CUDA
+
+# Simple CUDA test (if nvcc available)
+echo 'int main() { return 0; }' > test.cu && nvcc test.cu -o test && ./test && echo "CUDA works"
+```
+
+---
+
+## Common Issues & Solutions
+
+### VA-API Not Working
+
+**Symptom**: `vainfo` shows no profiles or errors
+
+**Solutions**:
+```bash
+# Check driver name
+echo $LIBVA_DRIVER_NAME
+
+# Intel: Should be "iHD"
+export LIBVA_DRIVER_NAME=iHD
+
+# NVIDIA: Should be "nvidia"
+export LIBVA_DRIVER_NAME=nvidia
+
+# Verify packages installed
+nix-store -q --requisites /run/current-system | grep -E "intel-media|libva-nvidia"
+```
+
+### Firefox Still Using Software Decode
+
+**Symptom**: High CPU during video playback
+
+**Solutions**:
+1. Check `about:config`:
+   - `media.ffmpeg.vaapi.enabled` = true
+   - `media.hardware-video-decoding.force-enabled` = true
+2. Restart Firefox
+3. Check `about:support` for "Hardware Video Decoding"
+
+### Bluetooth Codec Stuck on SBC
+
+**Symptom**: `pactl` shows SBC instead of LDAC/aptX
+
+**Solutions**:
+```bash
+# Restart WirePlumber
+systemctl --user restart wireplumber
+
+# Check codec config
+cat /etc/wireplumber/wireplumber.conf.d/*.conf | grep -i codec
+
+# Verify device supports higher codecs
+bluetoothctl info <MAC>
+```
+
+### NVIDIA Wayland Issues
+
+**Symptom**: Black screen, cursor issues, or crashes
+
+**Solutions**:
+```bash
+# Verify kernel parameters
+cat /proc/cmdline | grep nvidia
+# Expected: nvidia-drm.modeset=1
+
+# Check environment
+echo $GBM_BACKEND  # Should be nvidia-drm
+echo $WLR_NO_HARDWARE_CURSORS  # Should be 1
+
+# Start Sway with debug
+sway --unsupported-gpu 2>&1 | tee sway.log
+```
+
+---
+
+## Quick Reference Card
+
+| Feature | Verification Command | Expected |
+|---------|---------------------|----------|
+| Intel VA-API | `vainfo` | iHD driver, H264/HEVC profiles |
+| NVIDIA VA-API | `vainfo` | nvidia driver, H264/HEVC profiles |
+| GPU Rendering | `glxinfo \| grep renderer` | GPU name (not llvmpipe) |
+| Firefox HW | `about:support` | Hardware Video Decoding: ENABLED |
+| Webcam | `v4l2-ctl --list-devices` | /dev/video0 listed |
+| Bluetooth | `pactl list sinks` | LDAC/aptX codec shown |
+| Audio Latency | `pw-top` | Quantum ~256 |
+| Thunderbolt | `boltctl list` | Devices listed |
+| CUDA | `nvcc --version` | CUDA 12.x |
+| OpenCL | `clinfo` | NVIDIA/Intel platform |
+
+---
+
+## Performance Targets
+
+| Metric | Target | Verification |
+|--------|--------|--------------|
+| Video CPU usage | <20% for 1080p60 | `htop` during YouTube |
+| Screen recording CPU | <30% for 1080p60 | `htop` during wf-recorder |
+| Audio latency | <15ms | `pw-profiler` |
+| Compositor FPS | 60fps | `swaymsg -t get_outputs` |
+| Bluetooth codec | LDAC (990kbps) | `pactl list sinks` |

--- a/specs/115-enable-advanced-hardware-features/research.md
+++ b/specs/115-enable-advanced-hardware-features/research.md
@@ -1,0 +1,429 @@
+# Research: Enable Advanced Hardware Features
+
+**Feature**: 115-enable-advanced-hardware-features
+**Date**: 2025-12-13
+
+## Overview
+
+This document consolidates research findings for enabling advanced hardware features on ThinkPad (Intel Core Ultra 7 155U / Intel Arc) and Ryzen desktop (AMD 7600X3D / NVIDIA RTX 5070) systems.
+
+---
+
+## 1. Intel Arc GPU Hardware Acceleration (ThinkPad)
+
+### Decision
+Use `intel-media-driver` (iHD backend) with `vpl-gpu-rt` for VA-API hardware video encoding/decoding on Intel Arc (Meteor Lake).
+
+### Rationale
+- Intel Arc uses the modern iHD VA-API driver (not legacy i965)
+- Supports hardware decode: H.264, HEVC, VP9, AV1
+- Supports hardware encode: H.264, HEVC (via QuickSync/VPL)
+- Firefox uses VA-API through `media.ffmpeg.vaapi.enabled`
+
+### Configuration
+
+```nix
+# hardware/thinkpad.nix
+hardware.graphics.extraPackages = with pkgs; [
+  intel-media-driver      # VA-API iHD backend
+  intel-compute-runtime   # OpenCL for Intel Arc
+  vpl-gpu-rt             # Intel VPL (QuickSync replacement)
+  intel-ocl              # Additional OpenCL
+];
+
+# Environment variable
+environment.sessionVariables.LIBVA_DRIVER_NAME = "iHD";
+```
+
+### Verification Commands
+```bash
+vainfo                    # Should show iHD driver with decode/encode profiles
+intel_gpu_top             # Real-time GPU utilization
+```
+
+### Alternatives Considered
+- **i965 driver**: Legacy, not supported on Arc/Meteor Lake - REJECTED
+- **Mesa VA-API**: Less complete for Intel encode - REJECTED
+
+---
+
+## 2. NVIDIA Hardware Video (Ryzen Desktop)
+
+### Decision
+Use NVIDIA proprietary drivers with VA-API bridge (`libva-nvidia-driver`) for hardware video decode in Firefox. Use NVENC for screen recording.
+
+### Rationale
+- NVIDIA NVDEC (6th gen on RTX 5070) provides hardware H.264/HEVC/VP9/AV1 decode
+- NVIDIA NVENC (9th gen on RTX 5070) provides real-time encoding
+- Firefox requires VA-API; NVIDIA provides `libva-nvidia-driver` bridge
+- RTX 5070 (Blackwell) is new enough for open-source kernel modules
+
+### Configuration
+
+```nix
+# configurations/ryzen.nix
+hardware.nvidia = {
+  package = config.boot.kernelPackages.nvidiaPackages.stable;
+  modesetting.enable = true;
+  powerManagement.enable = true;
+  open = true;  # Use open-source kernel modules for RTX 30+
+};
+
+environment.sessionVariables = {
+  LIBVA_DRIVER_NAME = "nvidia";
+  GBM_BACKEND = "nvidia-drm";
+  __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+};
+```
+
+### Verification Commands
+```bash
+nvidia-smi dmon           # Monitor decoder/encoder utilization
+nvtop                     # TUI GPU monitoring
+vainfo                    # Should show NVIDIA VA-API profiles
+```
+
+### Alternatives Considered
+- **VDPAU only**: Firefox doesn't support VDPAU, needs VA-API - REJECTED
+- **Nouveau driver**: No hardware decode support - REJECTED
+
+---
+
+## 3. Firefox Hardware Video Decoding
+
+### Decision
+Enable VA-API hardware decoding in Firefox via about:config settings and environment variables.
+
+### Rationale
+- Firefox 115+ has stable VA-API support on Wayland
+- Hardware decode reduces CPU usage from 60%+ to <20% for 1080p60
+- Works with both Intel (iHD) and NVIDIA (libva-nvidia-driver) backends
+
+### Configuration
+
+```nix
+# home-modules/tools/firefox.nix
+programs.firefox.profiles.<profile>.settings = {
+  "media.ffmpeg.vaapi.enabled" = true;
+  "media.hardware-video-decoding.force-enabled" = true;
+  "media.av1.enabled" = true;
+  "gfx.webrender.all" = true;
+};
+
+# System-wide
+environment.sessionVariables.MOZ_ENABLE_WAYLAND = "1";
+```
+
+### Verification Commands
+```bash
+# In Firefox, navigate to:
+about:support   # Check "Hardware Video Decoding" shows ENABLED
+about:media     # Check video playback uses hardware decoder
+
+# While playing video:
+intel_gpu_top   # (Intel) Decoder should show utilization
+nvidia-smi dmon # (NVIDIA) Dec column should show activity
+```
+
+### Known Issues
+- Intel Arc (Meteor Lake) may have artifacts in Chromium/Electron (Firefox is fine)
+- NVIDIA OBS NVENC doesn't work with open-source kernel modules
+
+---
+
+## 4. Bluetooth High-Quality Audio Codecs
+
+### Decision
+Configure WirePlumber to enable SBC-XQ, AAC, LDAC, aptX, and aptX HD codecs with automatic quality negotiation.
+
+### Rationale
+- LDAC provides 990kbps vs SBC's 328kbps (3x improvement)
+- aptX HD provides 576kbps with lower latency than LDAC
+- Modern Bluetooth headphones (Sony, Sennheiser) support LDAC
+- WirePlumber handles codec negotiation automatically
+
+### Configuration
+
+```nix
+# configurations/thinkpad.nix
+services.pipewire.wireplumber.extraConfig."10-bluez" = {
+  "monitor.bluez.properties" = {
+    "bluez5.enable-sbc-xq" = true;
+    "bluez5.enable-msbc" = true;
+    "bluez5.enable-hw-volume" = true;
+    "bluez5.codecs" = [ "sbc" "sbc_xq" "aac" "ldac" "aptx" "aptx_hd" ];
+  };
+};
+
+hardware.bluetooth = {
+  enable = true;
+  powerOnBoot = true;
+  settings.General = {
+    Enable = "Source,Sink,Media,Socket";
+    Experimental = true;  # Required for some codec features
+  };
+};
+```
+
+### Verification Commands
+```bash
+pactl list sinks        # Check connected Bluetooth device codec
+bluetoothctl info <MAC> # Device capabilities
+pw-top                  # Audio stream information
+```
+
+### Alternatives Considered
+- **PulseAudio Bluetooth modules**: Less codec support than WirePlumber - REJECTED
+- **Manual codec selection**: Complex, automatic negotiation works well - REJECTED
+
+---
+
+## 5. Webcam V4L2 Support
+
+### Decision
+Install V4L2 utilities and ensure proper udev rules for webcam access.
+
+### Rationale
+- Built-in ThinkPad webcams use standard V4L2 interface
+- USB webcams on Ryzen also use V4L2
+- Browser WebRTC requires proper /dev/videoN enumeration
+- Camera controls (brightness, contrast) via cameractrls
+
+### Configuration
+
+```nix
+# Already in configurations/thinkpad.nix
+environment.systemPackages = with pkgs; [
+  v4l-utils         # V4L2 utilities (v4l2-ctl)
+  cameractrls       # Camera control GUI/CLI
+];
+
+# User in video group (already configured)
+users.users.vpittamp.extraGroups = [ "video" ];
+```
+
+### Verification Commands
+```bash
+v4l2-ctl --list-devices          # List webcam devices
+v4l2-ctl -d /dev/video0 --all    # Show camera capabilities
+cameractrls -d /dev/video0       # Camera control interface
+```
+
+### Known Issues
+- Intel MIPI/IPU6 drivers not yet packaged in NixOS (NixOS issue #225743)
+- Workaround: Most ThinkPads use USB-attached webcams that work fine
+
+---
+
+## 6. Hardware Screen Recording
+
+### Decision
+Use `wf-recorder` with VAAPI (Intel) or NVENC (NVIDIA) for hardware-accelerated screen recording.
+
+### Rationale
+- wf-recorder is native Wayland screen recorder
+- Supports VAAPI and NVENC hardware encoders
+- Minimal CPU usage (<30%) for 1080p60 capture
+- Alternative to OBS for quick recordings
+
+### Configuration
+
+```nix
+# home-modules/tools/screen-recording.nix (new module)
+environment.systemPackages = with pkgs; [
+  wf-recorder       # Wayland screen recorder
+  grim              # Screenshot utility
+  slurp             # Region selection
+];
+```
+
+### Usage Examples
+```bash
+# Intel QuickSync (VAAPI)
+wf-recorder -c h264_vaapi -o output.mp4
+
+# NVIDIA NVENC
+wf-recorder -c h264_nvenc -o output.mp4
+
+# Record specific output
+wf-recorder -o HEADLESS-1 -f recording.mp4
+```
+
+### Alternatives Considered
+- **OBS Studio**: Heavier, NVENC broken with open NVIDIA modules - ACCEPTABLE ALTERNATIVE
+- **ffmpeg direct**: Less convenient than wf-recorder - REJECTED
+
+---
+
+## 7. Thunderbolt/USB4 Support
+
+### Decision
+Enable Bolt daemon for Thunderbolt device authorization and security management.
+
+### Rationale
+- ThinkPad has Thunderbolt 4 ports for docking stations
+- Bolt daemon handles device authorization (security levels)
+- Kernel modules already configured in hardware/thinkpad.nix
+
+### Configuration
+
+```nix
+# configurations/thinkpad.nix
+services.hardware.bolt.enable = true;
+
+# Already in hardware/thinkpad.nix
+boot.initrd.availableKernelModules = [
+  "thunderbolt"
+  "xhci_pci"
+];
+```
+
+### Verification Commands
+```bash
+boltctl list              # List Thunderbolt devices
+boltctl info <UUID>       # Device details
+boltctl authorize <UUID>  # Authorize device
+```
+
+### Alternatives Considered
+- **No bolt daemon**: Devices may not authorize properly - REJECTED
+- **Manual sysfs access**: Less convenient than boltctl - REJECTED
+
+---
+
+## 8. PipeWire Low-Latency Audio
+
+### Decision
+Configure PipeWire with 256 quantum (5.3ms latency at 48kHz) for responsive audio.
+
+### Rationale
+- Low latency critical for speech-to-text and real-time audio
+- 256 quantum is good balance between latency and stability
+- JACK bridge enables pro audio applications
+- Already configured in both thinkpad.nix and ryzen.nix
+
+### Current Configuration
+
+```nix
+# Already in configurations/thinkpad.nix
+services.pipewire = {
+  enable = true;
+  alsa.enable = true;
+  pulse.enable = true;
+  jack.enable = true;
+
+  extraConfig.pipewire."92-low-latency" = {
+    "context.properties" = {
+      "default.clock.rate" = 48000;
+      "default.clock.quantum" = 256;       # 5.3ms latency
+      "default.clock.min-quantum" = 32;    # 0.67ms minimum
+      "default.clock.max-quantum" = 1024;  # 21ms maximum
+    };
+  };
+};
+
+security.rtkit.enable = true;  # Real-time scheduling
+```
+
+### Verification Commands
+```bash
+pw-top                           # Audio latency and buffer info
+pw-profiler                      # Profile audio pipeline
+pactl info | grep "Default"      # Default audio devices
+```
+
+---
+
+## 9. CUDA/OpenCL Compute (Ryzen Desktop)
+
+### Decision
+Install CUDA toolkit for GPU compute workloads. OpenCL available via NVIDIA drivers.
+
+### Rationale
+- RTX 5070 has significant compute capability for AI/ML workloads
+- CUDA 12.x compatible with Blackwell architecture
+- OpenCL available through NVIDIA drivers automatically
+
+### Configuration
+
+```nix
+# configurations/ryzen.nix - ADD
+environment.systemPackages = with pkgs; [
+  cudaPackages.cuda_nvcc    # CUDA compiler
+  clinfo                    # OpenCL verification
+  vulkan-tools              # Vulkan verification
+];
+```
+
+### Verification Commands
+```bash
+nvcc --version    # CUDA compiler version
+clinfo            # OpenCL platforms and devices
+vulkaninfo        # Vulkan capabilities
+```
+
+### Alternatives Considered
+- **ROCm (AMD)**: Not applicable, Ryzen has NVIDIA GPU - N/A
+- **CUDA via nix-shell**: Less convenient for development - ACCEPTABLE
+
+---
+
+## 10. Sway GPU-Accelerated Rendering
+
+### Decision
+Ensure Sway uses DRM/KMS modesetting for GPU-accelerated compositing (not pixman).
+
+### Rationale
+- Bare metal systems should use hardware GPU rendering
+- Hetzner VM correctly uses pixman (software) - no change needed
+- Intel uses modesetting driver (default)
+- NVIDIA requires specific environment variables
+
+### Configuration
+
+```nix
+# ThinkPad (Intel) - already using modesetting
+services.xserver.videoDrivers = [ "modesetting" ];
+
+# Ryzen (NVIDIA) - specific env vars for Wayland
+environment.sessionVariables = {
+  GBM_BACKEND = "nvidia-drm";
+  WLR_NO_HARDWARE_CURSORS = "1";  # Hardware cursor workaround
+};
+```
+
+### Verification
+```bash
+swaymsg -t get_outputs    # Check outputs are rendering
+glxinfo | grep "renderer" # Should show GPU, not llvmpipe
+```
+
+---
+
+## Summary of Decisions
+
+| Feature | Decision | Status |
+|---------|----------|--------|
+| Intel VA-API | intel-media-driver (iHD) | ✅ Already configured |
+| NVIDIA VA-API | libva-nvidia-driver via LIBVA_DRIVER_NAME=nvidia | ✅ Configured |
+| Firefox HW decode | media.ffmpeg.vaapi.enabled | ⚠️ Needs verification |
+| Bluetooth codecs | WirePlumber bluez5.codecs list | ✅ Already configured |
+| Webcam V4L2 | v4l-utils, cameractrls | ✅ Already installed |
+| Screen recording | wf-recorder with VA-API/NVENC | ⚠️ Add wf-recorder |
+| Thunderbolt | services.hardware.bolt | ⚠️ Add bolt daemon |
+| PipeWire latency | 256 quantum @ 48kHz | ✅ Already configured |
+| CUDA/OpenCL | cudaPackages, clinfo | ⚠️ Add packages |
+| Sway GPU render | DRM/KMS modesetting | ✅ Already configured |
+
+---
+
+## Sources
+
+- [NixOS Wiki - Intel Graphics](https://nixos.wiki/wiki/Intel_Graphics)
+- [NixOS Wiki - NVIDIA](https://nixos.wiki/wiki/Nvidia)
+- [NixOS Wiki - Accelerated Video Playback](https://nixos.wiki/wiki/Accelerated_Video_Playback)
+- [NixOS Wiki - Bluetooth](https://nixos.wiki/wiki/Bluetooth)
+- [NixOS Wiki - CUDA](https://nixos.wiki/wiki/CUDA)
+- [PipeWire Wiki - Performance Tuning](https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Performance-Tuning)
+- [ArchWiki - Hardware Video Acceleration](https://wiki.archlinux.org/title/Hardware_video_acceleration)
+- [wf-recorder GitHub](https://github.com/ammen99/wf-recorder)

--- a/specs/115-enable-advanced-hardware-features/spec.md
+++ b/specs/115-enable-advanced-hardware-features/spec.md
@@ -1,0 +1,206 @@
+# Feature Specification: Enable Advanced Hardware Features
+
+**Feature Branch**: `115-enable-advanced-hardware-features`
+**Created**: 2025-12-13
+**Status**: Complete
+**Input**: User description: "Given our new devices (ThinkPad with Intel Core Ultra 7 155U and AMD Ryzen 7600X3D with NVIDIA RTX 5070), enhance configurations to incorporate advanced hardware functionality that was previously limited on Hetzner VM and M1. Focus on: webcam, GPU acceleration for Firefox/PWAs, Sway compositor features, Bluetooth, audio/video playback, GTK-CSS rendering, and NixOS hardware repository capabilities."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Hardware-Accelerated Video Playback in Firefox (Priority: P1)
+
+When watching videos in Firefox or Firefox PWAs on bare metal devices, the user should experience smooth, power-efficient playback using GPU hardware decoding instead of CPU-intensive software rendering.
+
+**Why this priority**: Video consumption is a primary use case for web browsing. Hardware acceleration reduces CPU load by 80-90%, extends battery life on ThinkPad, and provides smooth 4K/HDR playback. This was impossible on Hetzner (pixman renderer).
+
+**Independent Test**: Open YouTube, play a 4K video, verify GPU utilization via `intel_gpu_top` (ThinkPad) or `nvtop` (Ryzen) shows decoder activity, while CPU usage remains low (<20%).
+
+**Acceptance Scenarios**:
+
+1. **Given** Firefox is launched on ThinkPad, **When** user plays a YouTube video, **Then** VA-API hardware decoding is used (verifiable via `about:support` showing "Hardware Video Decoding" enabled)
+2. **Given** Firefox is launched on Ryzen desktop, **When** user plays a YouTube video, **Then** NVIDIA NVDEC hardware decoding is active (verifiable via `nvidia-smi dmon` showing decoder utilization)
+3. **Given** a Firefox PWA (e.g., YouTube PWA) is launched, **When** user plays video content, **Then** the same hardware decoding path is used as native Firefox
+
+---
+
+### User Story 2 - Webcam Video Conferencing Support (Priority: P1)
+
+The user should be able to use the built-in webcam (ThinkPad) or USB webcam (Ryzen desktop) for video conferencing applications in Firefox and Electron apps.
+
+**Why this priority**: Video conferencing is essential for remote work. The Hetzner VM has no webcam hardware. Both new devices support real V4L2 camera access.
+
+**Independent Test**: Open Firefox, navigate to a video conferencing site (meet.google.com), verify camera preview shows live video feed and can be selected in browser settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a webcam is connected/built-in, **When** user opens browser camera settings, **Then** the webcam appears as a selectable device
+2. **Given** a video conference is started, **When** user enables camera, **Then** video stream transmits without errors and at native resolution
+3. **Given** multiple camera applications request access, **When** user switches between apps, **Then** camera is released properly and available to the next app
+
+---
+
+### User Story 3 - Bluetooth Audio with High-Quality Codecs (Priority: P2)
+
+On ThinkPad, the user should be able to pair Bluetooth headphones/speakers and use high-quality audio codecs (AAC, LDAC, aptX) for superior wireless audio quality.
+
+**Why this priority**: Bluetooth audio is a common use case for laptops. The current configuration enables Bluetooth but codec selection may not use the highest quality available. LDAC provides 990kbps vs SBC's 328kbps.
+
+**Independent Test**: Pair Sony WH-1000XM series headphones, verify via `pactl list sinks` that LDAC codec is active, play audio and confirm high-quality output.
+
+**Acceptance Scenarios**:
+
+1. **Given** Bluetooth headphones are paired, **When** audio plays, **Then** the highest quality available codec is automatically selected (LDAC > aptX HD > aptX > AAC > SBC)
+2. **Given** Bluetooth headphones support microphone, **When** user switches to headset profile, **Then** mSBC codec is used for telephony with clear voice quality
+3. **Given** audio is playing via Bluetooth, **When** user adjusts volume, **Then** hardware volume control is used (not software scaling)
+
+---
+
+### User Story 4 - GPU-Accelerated Screen Recording (Priority: P2)
+
+The user should be able to record screen content (for demos, tutorials, etc.) using hardware video encoding for efficient, high-quality capture without significant CPU load.
+
+**Why this priority**: Screen recording is useful for documentation, bug reports, and content creation. Hardware encoding (Intel QuickSync or NVIDIA NVENC) provides real-time encoding at minimal CPU cost - not possible on Hetzner.
+
+**Independent Test**: Start screen recording with `wf-recorder` using hardware encoder, verify via system monitor that CPU usage stays under 30% during 1080p60 capture.
+
+**Acceptance Scenarios**:
+
+1. **Given** ThinkPad with Intel Arc GPU, **When** user records screen with `wf-recorder`, **Then** VAAPI hardware encoder is used (QuickSync)
+2. **Given** Ryzen desktop with RTX 5070, **When** user records screen, **Then** NVENC hardware encoder is available
+3. **Given** a recording is in progress, **When** user performs normal desktop tasks, **Then** system remains responsive (no frame drops or lag)
+
+---
+
+### User Story 5 - NVIDIA GPU Computing for Development (Priority: P2)
+
+On the Ryzen desktop, the user should be able to utilize the RTX 5070 GPU for CUDA/OpenCL compute tasks (AI/ML development, video transcoding, etc.).
+
+**Why this priority**: The RTX 5070 is a significant compute resource. Enabling CUDA development unlocks AI/ML workflows, video processing acceleration, and GPU compute capabilities not available on other systems.
+
+**Independent Test**: Run `clinfo` and verify NVIDIA OpenCL platform is available; compile and run a simple CUDA program.
+
+**Acceptance Scenarios**:
+
+1. **Given** CUDA toolkit is installed, **When** user runs `nvcc --version`, **Then** CUDA compiler is available
+2. **Given** user runs `clinfo`, **When** output is displayed, **Then** NVIDIA GPU appears as an OpenCL compute device
+3. **Given** user runs Vulkan compute shader, **When** executed, **Then** RTX 5070 ray tracing cores are utilized
+
+---
+
+### User Story 6 - Smooth GTK/Sway Compositor Performance (Priority: P3)
+
+Desktop animations, window transitions, and GTK application rendering should be smooth and GPU-accelerated on both devices.
+
+**Why this priority**: Smooth UI contributes to a polished user experience. The Hetzner VM uses software rendering (pixman/cairo) which can be sluggish for animations. Bare metal GPUs enable hardware-accelerated compositing.
+
+**Independent Test**: Enable window animations in Sway, resize windows rapidly, verify smooth 60fps rendering without tearing.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sway compositor is running on ThinkPad, **When** user switches workspaces, **Then** transition completes smoothly without visible stutter
+2. **Given** GTK4 application is launched, **When** user interacts with UI, **Then** animations render via GPU (not cairo software fallback)
+3. **Given** Eww widgets are updating, **When** monitoring panel refreshes, **Then** updates complete without visible lag
+
+---
+
+### User Story 7 - Thunderbolt/USB4 Dock Support (Priority: P3)
+
+On ThinkPad, the user should be able to connect Thunderbolt/USB4 docks for external displays, USB peripherals, and charging via a single cable.
+
+**Why this priority**: Thunderbolt docks enable a "dock and work" workflow with external monitors, keyboard, mouse, and power via one connection. This requires hardware support not available on VMs.
+
+**Independent Test**: Connect Thunderbolt dock, verify external display appears in `swaymsg -t get_outputs`, USB devices enumerate, and laptop charges.
+
+**Acceptance Scenarios**:
+
+1. **Given** Thunderbolt dock is connected, **When** external monitor is attached to dock, **Then** display is detected and usable in Sway
+2. **Given** USB devices are connected through dock, **When** user lists devices, **Then** all devices appear in `lsusb` output
+3. **Given** dock provides power delivery, **When** connected, **Then** laptop battery shows "Charging" status
+
+---
+
+### User Story 8 - Low-Latency Audio for Real-Time Applications (Priority: P3)
+
+The user should have access to low-latency audio for real-time audio applications (speech-to-text, audio editing, music production).
+
+**Why this priority**: Low-latency audio is important for real-time voice applications and professional audio work. PipeWire can achieve <10ms latency with proper configuration on real hardware.
+
+**Independent Test**: Run `pw-top`, verify audio quantum is 256 samples (~5ms at 48kHz), test speech-to-text recognition for responsive transcription.
+
+**Acceptance Scenarios**:
+
+1. **Given** PipeWire is running, **When** user checks `pw-top`, **Then** audio latency is under 10ms
+2. **Given** speech-to-text is active, **When** user speaks, **Then** transcription appears within 500ms of speech completion
+3. **Given** JACK-compatible app is launched, **When** audio is routed, **Then** PipeWire JACK bridge provides seamless integration
+
+---
+
+### Edge Cases
+
+- What happens when GPU driver crashes during hardware decoding? System should fall back to software decoding without crashing the browser.
+- How does system handle Bluetooth audio codec negotiation failure? Should fall back to mandatory SBC codec.
+- What happens when Thunderbolt device authorization fails? User should see clear error via bolt daemon notification.
+- How does system handle webcam being in use by another application? Browser should show "camera in use" error, not crash.
+- What happens when NVIDIA driver version mismatch occurs? System should fail with clear error message during boot/login.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST enable VA-API hardware video decoding on Intel Arc GPU (ThinkPad) with `intel-media-driver` and appropriate environment variables
+- **FR-002**: System MUST enable NVIDIA NVDEC/NVENC on RTX 5070 (Ryzen) with NVIDIA proprietary drivers and VA-API/NVDEC bridges
+- **FR-003**: Firefox MUST be configured to use hardware video decoding on both platforms via `media.ffmpeg.vaapi.enabled` and related settings
+- **FR-004**: System MUST load Video4Linux (V4L2) modules and include `v4l-utils` for webcam support
+- **FR-005**: System MUST configure PipeWire with WirePlumber to enable high-quality Bluetooth audio codecs (SBC-XQ, AAC, LDAC, aptX, aptX HD) on ThinkPad
+- **FR-006**: System MUST include hardware-accelerated screen recording tools (`wf-recorder`, `grim`, `slurp`) configured to use available GPU encoders
+- **FR-007**: System MUST enable Thunderbolt/USB4 support via `bolt` daemon and appropriate kernel modules on ThinkPad
+- **FR-008**: System MUST configure PipeWire with low-latency settings (256 quantum, 48kHz sample rate) on both platforms
+- **FR-009**: Sway compositor MUST use hardware-accelerated rendering (DRM/KMS modesetting) instead of software renderer
+- **FR-010**: System MUST enable CUDA toolkit and OpenCL support on Ryzen desktop for GPU compute workloads
+- **FR-011**: GTK applications MUST use hardware-accelerated rendering where available (not forced to cairo software fallback)
+- **FR-012**: System MUST include GPU monitoring tools appropriate to each platform (`intel_gpu_top` for Intel, `nvtop` for NVIDIA)
+
+### Key Entities
+
+- **Hardware Profile**: Platform-specific configuration (ThinkPad Intel, Ryzen NVIDIA) with GPU drivers, kernel modules, and environment variables
+- **Video Acceleration Stack**: VA-API/VDPAU backends, browser configurations, and verification tools for hardware video decoding
+- **Audio Pipeline**: PipeWire configuration with codec support, latency settings, and device routing
+- **Peripheral Support**: Webcam (V4L2), Bluetooth (BlueZ), Thunderbolt (bolt), USB subsystems
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Video playback in Firefox uses less than 20% CPU for 1080p60 content (vs 60%+ with software decoding)
+- **SC-002**: Webcam video stream achieves native sensor resolution with less than 100ms capture-to-display latency
+- **SC-003**: Bluetooth audio connects within 5 seconds and uses high-quality codec (LDAC/aptX when supported by device)
+- **SC-004**: Screen recording at 1080p60 uses less than 30% CPU via hardware encoder
+- **SC-005**: Audio round-trip latency is under 15ms as measured by PipeWire diagnostics
+- **SC-006**: Sway workspace switching completes within 50ms (smooth 60fps animation)
+- **SC-007**: Thunderbolt dock connection establishes within 10 seconds of physical connection
+- **SC-008**: GPU compute workloads (CUDA/OpenCL) execute on dedicated GPU hardware, not CPU fallback
+- **SC-009**: Configuration builds successfully on both ThinkPad and Ryzen targets without hardware-specific errors on opposite platform
+
+## Assumptions
+
+The following reasonable defaults and assumptions are made:
+
+1. **Firefox as primary browser**: The specification focuses on Firefox hardware acceleration. Chromium/Electron apps will inherit system-wide VA-API settings via `NIXOS_OZONE_WL=1`.
+
+2. **No HDR requirement**: HDR/color management is deferred as Sway support is immature. Standard dynamic range is assumed sufficient.
+
+3. **Intel NPU not enabled**: Intel NPU driver is not packaged in NixOS yet (issue #348739). This is excluded from current scope.
+
+4. **NVIDIA open-source kernel modules**: RTX 5070 (Blackwell) is new enough to use NVIDIA's open-source kernel modules (`hardware.nvidia.open = true`).
+
+5. **Single GPU per system**: No multi-GPU or GPU passthrough configuration is in scope. Ryzen uses only the RTX 5070, not any integrated graphics.
+
+6. **Hetzner VM unchanged**: The Hetzner configuration will remain with software rendering (pixman). No attempt to enable hardware features on VM.
+
+7. **Bluetooth on ThinkPad only**: Ryzen desktop is assumed to not have Bluetooth hardware. If present, configuration is already in place via `hardware.bluetooth`.
+
+8. **Standard Bluetooth codecs**: No need to configure exotic codecs (LC3, LE Audio). Focus on widely-supported AAC/LDAC/aptX.
+
+9. **webcam resolution**: Webcam is assumed to be 1080p or lower. No specific 4K webcam support required.
+
+10. **Gaming disabled**: Neither system has gaming enabled (`services.bare-metal.enableGaming = false`). No Steam/Proton/GameMode optimization required.

--- a/specs/115-enable-advanced-hardware-features/tasks.md
+++ b/specs/115-enable-advanced-hardware-features/tasks.md
@@ -1,0 +1,303 @@
+# Tasks: Enable Advanced Hardware Features
+
+**Input**: Design documents from `/specs/115-enable-advanced-hardware-features/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, quickstart.md
+
+**Tests**: Hardware testing requires manual verification; dry-build covers configuration validation. No automated tests generated.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+NixOS configuration files:
+- `configurations/` - Target system configurations
+- `hardware/` - Hardware-specific modules
+- `modules/` - Reusable NixOS modules
+- `home-modules/` - Home-manager user modules
+
+---
+
+## Phase 1: Setup (Build Verification)
+
+**Purpose**: Verify existing configurations build successfully before modifications
+
+- [x] T001 Run dry-build for ThinkPad configuration: `sudo nixos-rebuild dry-build --flake .#thinkpad`
+- [x] T002 [P] Run dry-build for Ryzen configuration: `sudo nixos-rebuild dry-build --flake .#ryzen`
+- [x] T003 [P] Run dry-build for Hetzner configuration to ensure no regression: `sudo nixos-rebuild dry-build --flake .#hetzner-sway`
+
+**Checkpoint**: All three configurations build successfully before any modifications
+
+---
+
+## Phase 2: Foundational (Environment Variables & Packages)
+
+**Purpose**: Add environment variables and base packages needed by multiple user stories
+
+**⚠️ CRITICAL**: These changes enable hardware acceleration across multiple features
+
+- [x] T004 Add LIBVA_DRIVER_NAME="iHD" to environment.sessionVariables in configurations/thinkpad.nix
+- [x] T005 [P] Verify LIBVA_DRIVER_NAME="nvidia" exists in environment.sessionVariables in configurations/ryzen.nix
+- [x] T006 [P] Add wf-recorder, grim, slurp to environment.systemPackages in configurations/thinkpad.nix
+- [x] T007 [P] Add wf-recorder, grim, slurp to environment.systemPackages in configurations/ryzen.nix
+- [x] T008 Verify intel-gpu-tools (intel_gpu_top) is in environment.systemPackages in configurations/thinkpad.nix
+- [x] T009 [P] Verify nvtopPackages.nvidia (nvtop) is in environment.systemPackages in configurations/ryzen.nix
+- [x] T010 Run dry-build for both targets to verify foundational changes: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: Foundation ready - hardware-specific user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 - Hardware-Accelerated Video Playback (Priority: P1) 🎯 MVP
+
+**Goal**: Enable GPU hardware video decoding in Firefox on both ThinkPad (VA-API/Intel) and Ryzen (NVDEC/NVIDIA)
+
+**Independent Test**: Play YouTube 4K video, verify GPU decoder active via `intel_gpu_top` or `nvtop`, CPU usage <20%
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Verify intel-media-driver is in hardware.graphics.extraPackages in hardware/thinkpad.nix
+- [x] T012 [P] [US1] Verify vpl-gpu-rt (Intel VPL/QuickSync) is in hardware.graphics.extraPackages in hardware/thinkpad.nix
+- [x] T013 [P] [US1] Verify libva-utils package is in environment.systemPackages in configurations/thinkpad.nix
+- [x] T014 [P] [US1] Verify libva-utils package is in environment.systemPackages in configurations/ryzen.nix
+- [x] T015 [US1] Add Firefox hardware video decoding settings to home-modules/tools/firefox.nix: media.ffmpeg.vaapi.enabled=true, media.hardware-video-decoding.force-enabled=true, gfx.webrender.all=true
+- [x] T016 [US1] Run dry-build for ThinkPad: `sudo nixos-rebuild dry-build --flake .#thinkpad`
+- [x] T017 [US1] Run dry-build for Ryzen: `sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 1 configuration complete - ready for hardware verification after apply
+
+---
+
+## Phase 4: User Story 2 - Webcam Video Conferencing (Priority: P1)
+
+**Goal**: Enable V4L2 webcam access for video conferencing in Firefox and Electron apps
+
+**Independent Test**: Run `v4l2-ctl --list-devices`, verify webcam appears; test in browser at meet.google.com
+
+### Implementation for User Story 2
+
+- [x] T018 [US2] Verify v4l-utils is in environment.systemPackages in configurations/thinkpad.nix
+- [x] T019 [P] [US2] Verify cameractrls is in environment.systemPackages in configurations/thinkpad.nix
+- [x] T020 [P] [US2] Add v4l-utils to environment.systemPackages in configurations/ryzen.nix (for USB webcams)
+- [x] T021 [US2] Verify user vpittamp is in "video" group in configurations/thinkpad.nix
+- [x] T022 [P] [US2] Verify user vpittamp is in "video" group in configurations/ryzen.nix
+- [x] T023 [US2] Run dry-build for both targets: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 2 configuration complete - ready for hardware verification
+
+---
+
+## Phase 5: User Story 3 - Bluetooth High-Quality Audio Codecs (Priority: P2)
+
+**Goal**: Enable LDAC, aptX HD, aptX, AAC codecs for Bluetooth audio on ThinkPad
+
+**Independent Test**: Pair Bluetooth headphones, check `pactl list sinks | grep codec`, verify LDAC/aptX active
+
+### Implementation for User Story 3
+
+- [x] T024 [US3] Verify WirePlumber bluez5.codecs configuration in services.pipewire.wireplumber.extraConfig in configurations/thinkpad.nix includes ["sbc", "sbc_xq", "aac", "ldac", "aptx", "aptx_hd"]
+- [x] T025 [US3] Verify bluez5.enable-sbc-xq=true in WirePlumber config in configurations/thinkpad.nix
+- [x] T026 [P] [US3] Verify bluez5.enable-msbc=true for telephony in WirePlumber config in configurations/thinkpad.nix
+- [x] T027 [P] [US3] Verify bluez5.enable-hw-volume=true in WirePlumber config in configurations/thinkpad.nix
+- [x] T028 [US3] Verify hardware.bluetooth.settings.General.Experimental=true in configurations/thinkpad.nix
+- [x] T029 [US3] Run dry-build for ThinkPad: `sudo nixos-rebuild dry-build --flake .#thinkpad`
+
+**Checkpoint**: User Story 3 configuration complete - ready for Bluetooth hardware verification
+
+---
+
+## Phase 6: User Story 4 - GPU-Accelerated Screen Recording (Priority: P2)
+
+**Goal**: Enable hardware-encoded screen recording via wf-recorder with VAAPI/NVENC
+
+**Independent Test**: Run `wf-recorder -c h264_vaapi -f test.mp4` (Intel) or `wf-recorder -c h264_nvenc -f test.mp4` (NVIDIA), verify CPU <30%
+
+### Implementation for User Story 4
+
+- [x] T030 [US4] Verify wf-recorder is in environment.systemPackages (added in T006/T007)
+- [x] T031 [P] [US4] Verify grim (screenshot tool) is in environment.systemPackages
+- [x] T032 [P] [US4] Verify slurp (region selection) is in environment.systemPackages
+- [x] T033 [US4] Verify VA-API environment is configured (LIBVA_DRIVER_NAME set in foundational phase)
+- [x] T034 [US4] Run dry-build for both targets: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 4 configuration complete - ready for screen recording verification
+
+---
+
+## Phase 7: User Story 5 - NVIDIA GPU Computing (Priority: P2)
+
+**Goal**: Enable CUDA toolkit and OpenCL for GPU compute workloads on Ryzen desktop
+
+**Independent Test**: Run `nvcc --version` for CUDA compiler, `clinfo` for OpenCL platforms
+
+### Implementation for User Story 5
+
+- [x] T035 [US5] Add cudaPackages.cuda_nvcc to environment.systemPackages in configurations/ryzen.nix
+- [x] T036 [P] [US5] Add clinfo to environment.systemPackages in configurations/ryzen.nix
+- [x] T037 [P] [US5] Verify vulkan-tools is in environment.systemPackages in configurations/ryzen.nix
+- [x] T038 [US5] Run dry-build for Ryzen: `sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 5 configuration complete - ready for CUDA/OpenCL verification
+
+---
+
+## Phase 8: User Story 6 - Smooth GTK/Sway Compositor Performance (Priority: P3)
+
+**Goal**: Ensure Sway uses GPU-accelerated rendering (DRM/KMS) instead of software pixman
+
+**Independent Test**: Run `glxinfo | grep renderer`, verify shows GPU name not llvmpipe
+
+### Implementation for User Story 6
+
+- [x] T039 [US6] Verify services.xserver.videoDrivers = ["modesetting"] in configurations/thinkpad.nix
+- [x] T040 [P] [US6] Verify services.xserver.videoDrivers = ["nvidia"] in configurations/ryzen.nix
+- [x] T041 [P] [US6] Verify GBM_BACKEND="nvidia-drm" in environment.sessionVariables in configurations/ryzen.nix
+- [x] T042 [P] [US6] Verify WLR_NO_HARDWARE_CURSORS="1" in environment.sessionVariables in configurations/ryzen.nix
+- [x] T043 [US6] Verify hardware.nvidia.modesetting.enable=true in configurations/ryzen.nix
+- [x] T044 [US6] Run dry-build for both targets: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 6 configuration complete - ready for compositor performance verification
+
+---
+
+## Phase 9: User Story 7 - Thunderbolt/USB4 Dock Support (Priority: P3)
+
+**Goal**: Enable Bolt daemon for Thunderbolt device authorization on ThinkPad
+
+**Independent Test**: Connect Thunderbolt dock, run `boltctl list`, verify device appears
+
+### Implementation for User Story 7
+
+- [x] T045 [US7] Add services.hardware.bolt.enable = true to configurations/thinkpad.nix
+- [x] T046 [US7] Verify "thunderbolt" is in boot.initrd.availableKernelModules in hardware/thinkpad.nix
+- [x] T047 [US7] Run dry-build for ThinkPad: `sudo nixos-rebuild dry-build --flake .#thinkpad`
+
+**Checkpoint**: User Story 7 configuration complete - ready for Thunderbolt dock verification
+
+---
+
+## Phase 10: User Story 8 - Low-Latency Audio (Priority: P3)
+
+**Goal**: Configure PipeWire with 256 quantum for <15ms audio latency
+
+**Independent Test**: Run `pw-top`, verify quantum ~256 and rate 48000
+
+### Implementation for User Story 8
+
+- [x] T048 [US8] Verify services.pipewire.extraConfig.pipewire."92-low-latency" is configured in configurations/thinkpad.nix with quantum=256, rate=48000
+- [x] T049 [P] [US8] Verify services.pipewire.extraConfig.pipewire."92-low-latency" is configured in configurations/ryzen.nix with quantum=256, rate=48000
+- [x] T050 [US8] Verify security.rtkit.enable=true in configurations/thinkpad.nix
+- [x] T051 [P] [US8] Verify security.rtkit.enable=true in configurations/ryzen.nix
+- [x] T052 [US8] Verify services.pipewire.jack.enable=true for JACK bridge compatibility in configurations/thinkpad.nix
+- [x] T053 [P] [US8] Verify services.pipewire.jack.enable=true in configurations/ryzen.nix
+- [x] T054 [US8] Run dry-build for both targets: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen`
+
+**Checkpoint**: User Story 8 configuration complete - ready for audio latency verification
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final verification, and apply changes
+
+- [x] T055 [P] Update CLAUDE.md with hardware verification commands from quickstart.md
+- [x] T056 [P] Add hardware feature section to CLAUDE.md documenting new capabilities
+- [x] T057 Run final dry-build for all three targets to ensure no regressions: `sudo nixos-rebuild dry-build --flake .#thinkpad && sudo nixos-rebuild dry-build --flake .#ryzen && sudo nixos-rebuild dry-build --flake .#hetzner-sway`
+- [ ] T058 Apply configuration to current system: `sudo nixos-rebuild switch --flake .#<current-target>`
+- [ ] T059 Run quickstart.md verification procedures for applied target
+- [x] T060 Update spec.md status from Draft to Complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verification only
+- **Foundational (Phase 2)**: Depends on Setup - adds shared env vars and packages
+- **User Stories (Phase 3-10)**: All depend on Foundational completion
+  - US1 (P1) and US2 (P1) can proceed in parallel - both P1 priority
+  - US3-US8 (P2-P3) can proceed in parallel after US1/US2 if desired
+- **Polish (Phase 11)**: Depends on all user stories being verified via dry-build
+
+### User Story Dependencies
+
+| Story | Priority | Depends On | Can Parallel With |
+|-------|----------|------------|-------------------|
+| US1 - Video Playback | P1 | Foundational | US2 |
+| US2 - Webcam | P1 | Foundational | US1 |
+| US3 - Bluetooth | P2 | Foundational | US4, US5 |
+| US4 - Screen Recording | P2 | Foundational | US3, US5 |
+| US5 - CUDA/OpenCL | P2 | Foundational | US3, US4 |
+| US6 - Compositor | P3 | Foundational | US7, US8 |
+| US7 - Thunderbolt | P3 | Foundational | US6, US8 |
+| US8 - Low-Latency Audio | P3 | Foundational | US6, US7 |
+
+### Parallel Opportunities
+
+- All [P] marked tasks within a phase can run in parallel
+- US1 and US2 (both P1) can be done in parallel
+- US3, US4, US5 (all P2) can be done in parallel
+- US6, US7, US8 (all P3) can be done in parallel
+- Many tasks are verification tasks (checking existing config) which can parallelize heavily
+
+---
+
+## Parallel Example: User Story 1 (Video Playback)
+
+```bash
+# Parallel verification tasks:
+Task: "Verify intel-media-driver is in hardware.graphics.extraPackages in hardware/thinkpad.nix"
+Task: "Verify vpl-gpu-rt is in hardware.graphics.extraPackages in hardware/thinkpad.nix"
+Task: "Verify libva-utils package is in configurations/thinkpad.nix"
+Task: "Verify libva-utils package is in configurations/ryzen.nix"
+
+# Then sequential (depends on above):
+Task: "Add Firefox hardware video decoding settings to home-modules/tools/firefox.nix"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup (verify builds)
+2. Complete Phase 2: Foundational (env vars + base packages)
+3. Complete Phase 3: User Story 1 (Video Playback)
+4. Complete Phase 4: User Story 2 (Webcam)
+5. **STOP and VALIDATE**: Apply config, test video playback and webcam
+6. Deploy if ready - MVP delivers the two P1 features
+
+### Incremental Delivery
+
+1. Setup + Foundational → Base ready
+2. Add US1 + US2 (P1) → Test → Apply (MVP!)
+3. Add US3 + US4 + US5 (P2) → Test → Apply
+4. Add US6 + US7 + US8 (P3) → Test → Apply
+5. Polish → Documentation complete
+
+### Single Developer Strategy
+
+Execute phases sequentially in priority order:
+1. Setup → Foundational → US1 → US2 → Apply → Test
+2. US3 → US4 → US5 → Apply → Test
+3. US6 → US7 → US8 → Apply → Test
+4. Polish → Done
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Most tasks are verification (existing config) or addition (new options)
+- dry-build validates configuration syntax; hardware testing requires applied config
+- Hetzner configuration should NOT be modified - verify no regression only
+- Many settings already exist - tasks focus on verification and gap-filling
+- Apply changes only after dry-build succeeds for target


### PR DESCRIPTION
## Summary

- Enable VA-API hardware video decoding on ThinkPad (Intel iHD driver) with proper environment variables
- Add Thunderbolt/USB4 support via bolt daemon for ThinkPad docking stations
- Add hardware-accelerated screen recording tools (wf-recorder, grim, slurp) for both platforms
- Add webcam V4L2 utilities for Ryzen USB webcam support

## Changes

**ThinkPad (Intel Core Ultra 7 155U)**:
- `LIBVA_DRIVER_NAME=iHD` - Intel VA-API driver selection
- `NIXOS_OZONE_WL=1` - Electron Wayland support
- `services.hardware.bolt.enable` - Thunderbolt device authorization
- Screen recording packages with QuickSync support

**Ryzen (AMD 7600X3D + NVIDIA RTX 5070)**:
- Screen recording packages with NVENC support
- `v4l-utils` for USB webcam

## Verification

Tested on ThinkPad:
- ✅ VA-API: Intel iHD driver 25.3.4 with H264/HEVC/VP9/AV1 encode/decode
- ✅ Webcam: Integrated Camera at /dev/video0
- ✅ Thunderbolt: bolt.service active
- ✅ PipeWire: v1.4.9 running with WirePlumber
- ✅ Bluetooth: Controller powered and ready
- ✅ GPU monitoring: intel_gpu_top working

## Test plan

- [x] `nixos-rebuild dry-build --flake .#thinkpad` passes
- [x] `nixos-rebuild dry-build --flake .#ryzen` passes
- [x] `nixos-rebuild dry-build --flake .#hetzner-sway` passes (no regressions)
- [x] Applied to ThinkPad and verified hardware features

🤖 Generated with [Claude Code](https://claude.com/claude-code)