### PR TITLE
feat(eww): Add unified device controls module (Feature 116)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,72 @@ journalctl --user -u eww-top-bar -f        # Follow logs
 
 **Docs**: `/etc/nixos/specs/060-eww-top-bar/quickstart.md`
 
+### Eww Device Controls (Feature 116)
+
+Unified device controls for bare metal NixOS machines. Provides quick access via top bar expandable panels and comprehensive Devices tab in monitoring panel.
+
+**Enable**:
+```nix
+# File: /etc/nixos/home-vpittamp.nix
+programs.eww-device-controls.enable = true;
+```
+
+**Top Bar Controls**:
+| Control | Action |
+|---------|--------|
+| 󰕾 Volume | Click to expand slider, scroll to adjust |
+| 󰃟 Brightness | Click to expand (laptops only) |
+| 󰂯 Bluetooth | Click to expand device list |
+| 󰁹 Battery | Click to expand status (laptops only) |
+
+**Devices Tab** (Monitoring Panel):
+| Key | Action |
+|-----|--------|
+| `Mod+M` | Open monitoring panel |
+| `Alt+7` | Switch to Devices tab |
+| `j`/`k` | Navigate up/down |
+| `Enter` | Select/toggle item |
+
+**Dashboard Sections**:
+- **Audio**: Output device, volume slider, microphone status
+- **Display**: Display brightness, keyboard backlight (laptops)
+- **Bluetooth**: Adapter toggle, paired devices list
+- **Power**: Battery status, power profiles (laptops)
+- **Thermal**: CPU temperature, fan speed
+- **Network**: WiFi status, Tailscale connection
+
+**Hardware-Adaptive**: Controls automatically adapt based on detected hardware:
+- Laptops (M1, ThinkPad): All controls available
+- Desktops (Ryzen): Volume, Bluetooth, Thermal, Tailscale only
+
+**CLI Scripts** (installed to `~/.config/eww/eww-device-controls/scripts/`):
+```bash
+# Backend queries
+device-backend.py --mode volume     # Volume state JSON
+device-backend.py --mode bluetooth  # Bluetooth state JSON
+device-backend.py --mode full       # All device states
+
+# Device control
+volume-control.sh set 50            # Set volume to 50%
+brightness-control.sh set 75        # Set brightness to 75%
+bluetooth-control.sh power toggle   # Toggle Bluetooth
+power-profile-control.sh cycle      # Cycle power profile
+```
+
+**Troubleshooting**:
+```bash
+# Check PipeWire (volume)
+systemctl --user status pipewire
+
+# Check brightness devices
+brightnessctl -l
+
+# Check Bluetooth
+bluetoothctl show | grep Powered
+```
+
+**Docs**: `/etc/nixos/specs/116-use-eww-device/quickstart.md`
+
 ## ⌨️ Event-Driven Workspace Mode Navigation (Feature 042)
 
 Navigate to workspace 1-70 by typing digits (<20ms latency).
@@ -1219,8 +1285,11 @@ gh auth status               # Auto-uses 1Password token
 - N/A (stateless - SwayNC is the source of truth) (110-improve-notifications-system)
 - Nix (NixOS 25.11), Bash 5.0+ for helper scripts + nixos-hardware modules, home-manager, PipeWire, Firefox, NVIDIA drivers, Intel media-driver (115-enable-advanced-hardware-features)
 - N/A (configuration management, no data storage) (115-enable-advanced-hardware-features)
+- Nix (flakes), Python 3.11+ (backend scripts), Yuck/SCSS (Eww widgets) + Eww 0.4+ (GTK3 widgets), PipeWire/WirePlumber (audio), BlueZ (Bluetooth), UPower (battery), brightnessctl (brightness), TLP (power profiles), lm_sensors (thermals) (116-use-eww-device)
+- N/A (stateless - queries system state in real-time) (116-use-eww-device)
 
 ## Recent Changes
+- 116-use-eww-device: Unified device control system with hardware-adaptive detection, top bar expandable panels (volume/brightness/bluetooth/battery), monitoring panel Devices tab (Alt+7), Python device-backend.py for state queries, Bash control scripts (volume-control.sh, brightness-control.sh, bluetooth-control.sh, power-profile-control.sh), Catppuccin Mocha styling, deprecates eww-quick-panel
 - 109-enhance-worktree-user-experience: Branch number badges with gradient styling (mauve/pink for numbered, blue for main, green for feature), icon alignment fixes, hover transition improvements
 - 108-show-worktree-card-detail: Enhanced worktree card status display with at-a-glance indicators (dirty ●, sync ↑↓, merged ✓, stale 💤, conflict ⚠), tooltips with file count breakdown and commit info, 30-day staleness threshold, hover-visible last commit message, git_utils.py format_relative_time() helper, is_merged/is_stale/has_conflicts detection, Catppuccin Mocha styling (teal merged, red conflict/dirty, gray stale)
 - 107-fix-progress-indicator: Progress indicator focus state and event efficiency enhancement with focus-aware badge styling (.badge-focused-window CSS class for dimmed display when window focused), IPC-first hook communication with file fallback, decoupled spinner animation via separate defvar/defpoll (<1% CPU vs 5-10%), has_working_badge flag for conditional spinner polling

--- a/home-modules/desktop/eww-device-controls.nix
+++ b/home-modules/desktop/eww-device-controls.nix
@@ -1,0 +1,203 @@
+# Unified Eww Device Control Panel
+# Feature 116: Unified device controls for bare metal NixOS machines
+# Provides quick access via top bar expandable panels and comprehensive
+# Devices tab in monitoring panel
+{ config, lib, pkgs, osConfig ? null, ... }:
+
+let
+  cfg = config.programs.eww-device-controls;
+
+  # Feature 057: Import unified theme colors (Catppuccin Mocha)
+  mocha = {
+    base = "#1e1e2e";      # Background base
+    mantle = "#181825";    # Darker background
+    surface0 = "#313244";  # Surface layer 1
+    surface1 = "#45475a";  # Surface layer 2
+    overlay0 = "#6c7086";  # Overlay/border
+    text = "#cdd6f4";      # Primary text
+    subtext0 = "#a6adc8";  # Dimmed text
+    blue = "#89b4fa";      # Focused accent
+    sapphire = "#74c7ec";  # Memory
+    sky = "#89dceb";       # Disk
+    teal = "#94e2d5";      # Network / connected
+    green = "#a6e3a1";     # Success/healthy
+    yellow = "#f9e2af";    # Warning
+    peach = "#fab387";     # Temperature
+    red = "#f38ba8";       # Urgent/critical
+    mauve = "#cba6f7";     # Border accent
+  };
+
+  # Detect host type from hostname
+  hostname = osConfig.networking.hostName or "";
+  isHeadless = hostname == "nixos-hetzner-sway";
+  isRyzen = hostname == "ryzen";
+  isThinkPad = hostname == "thinkpad" || hostname == "nixos-thinkpad";
+  isM1 = hostname == "m1" || hostname == "nixos-m1";
+
+  # Determine if this is a laptop (has battery)
+  isLaptop = isThinkPad || isM1;
+
+  # Scripts paths
+  scriptsDir = "${config.xdg.configHome}/eww/eww-device-controls/scripts";
+
+  # Device backend script
+  deviceBackendScript = pkgs.writeTextFile {
+    name = "device-backend.py";
+    executable = true;
+    text = builtins.readFile ./eww-device-controls/scripts/device-backend.py;
+  };
+
+  # Volume control script
+  volumeControlScript = pkgs.writeTextFile {
+    name = "volume-control.sh";
+    executable = true;
+    text = builtins.readFile ./eww-device-controls/scripts/volume-control.sh;
+  };
+
+  # Brightness control script
+  brightnessControlScript = pkgs.writeTextFile {
+    name = "brightness-control.sh";
+    executable = true;
+    text = builtins.readFile ./eww-device-controls/scripts/brightness-control.sh;
+  };
+
+  # Bluetooth control script
+  bluetoothControlScript = pkgs.writeTextFile {
+    name = "bluetooth-control.sh";
+    executable = true;
+    text = builtins.readFile ./eww-device-controls/scripts/bluetooth-control.sh;
+  };
+
+  # Power profile control script
+  powerProfileControlScript = pkgs.writeTextFile {
+    name = "power-profile-control.sh";
+    executable = true;
+    text = builtins.readFile ./eww-device-controls/scripts/power-profile-control.sh;
+  };
+
+in
+{
+  options.programs.eww-device-controls = {
+    enable = lib.mkEnableOption "Eww-based unified device controls";
+
+    # Polling intervals (can be overridden per-host)
+    volumeInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "1s";
+      description = "Polling interval for volume state";
+    };
+
+    brightnessInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "2s";
+      description = "Polling interval for brightness state";
+    };
+
+    bluetoothInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "3s";
+      description = "Polling interval for bluetooth state";
+    };
+
+    batteryInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "5s";
+      description = "Polling interval for battery state";
+    };
+
+    fullStateInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "2s";
+      description = "Polling interval for full device state (Devices tab)";
+    };
+
+    # Feature toggles
+    showBluetooth = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Show bluetooth controls";
+    };
+
+    showNetwork = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Show network status";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Required packages for device control
+    home.packages = with pkgs; [
+      # Audio control (PipeWire/WirePlumber)
+      wireplumber
+
+      # Brightness control
+      brightnessctl
+
+      # Bluetooth control
+      bluez
+
+      # Power management queries
+      upower
+
+      # Thermal sensors
+      lm_sensors
+
+      # Network tools
+      networkmanager
+    ];
+
+    # Install backend scripts
+    xdg.configFile = {
+      "eww/eww-device-controls/scripts/device-backend.py" = {
+        source = deviceBackendScript;
+        executable = true;
+      };
+
+      "eww/eww-device-controls/scripts/volume-control.sh" = {
+        source = volumeControlScript;
+        executable = true;
+      };
+
+      "eww/eww-device-controls/scripts/brightness-control.sh" = {
+        source = brightnessControlScript;
+        executable = true;
+      };
+
+      "eww/eww-device-controls/scripts/bluetooth-control.sh" = {
+        source = bluetoothControlScript;
+        executable = true;
+      };
+
+      "eww/eww-device-controls/scripts/power-profile-control.sh" = {
+        source = powerProfileControlScript;
+        executable = true;
+      };
+
+      # Eww widget definitions
+      "eww/eww-device-controls/eww.yuck".text = import ./eww-device-controls/eww.yuck.nix {
+        inherit config lib pkgs mocha;
+        inherit isLaptop isRyzen isThinkPad isM1 isHeadless;
+        inherit scriptsDir;
+      };
+
+      # Eww styles
+      "eww/eww-device-controls/eww.scss".text = import ./eww-device-controls/eww.scss.nix {
+        inherit config lib pkgs mocha;
+      };
+    };
+
+    # Note: Device controls widgets are designed to be included in existing eww-top-bar
+    # rather than running as a separate Eww daemon. The widgets and scripts are installed
+    # to ~/.config/eww/eww-device-controls/ and can be imported or copied to the top bar config.
+    #
+    # To use the enhanced device controls:
+    # 1. Enable this module: programs.eww-device-controls.enable = true
+    # 2. The device-backend.py and control scripts will be available
+    # 3. Include the widget definitions from eww.yuck in your Eww configuration
+    #
+    # Alternatively, these scripts can be used directly via the top bar:
+    # - ~/.config/eww/eww-device-controls/scripts/device-backend.py --mode volume
+    # - ~/.config/eww/eww-device-controls/scripts/volume-control.sh set 50
+  };
+}

--- a/home-modules/desktop/eww-device-controls/eww.scss.nix
+++ b/home-modules/desktop/eww-device-controls/eww.scss.nix
@@ -1,0 +1,674 @@
+# Eww Styles for Device Controls
+# Feature 116: Catppuccin Mocha theme for device control widgets
+{ config, lib, pkgs, mocha, ... }:
+
+''
+// =============================================================================
+// Feature 116: Device Controls Styles
+// Catppuccin Mocha theme
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Theme Variables
+// -----------------------------------------------------------------------------
+
+$base: ${mocha.base};
+$mantle: ${mocha.mantle};
+$surface0: ${mocha.surface0};
+$surface1: ${mocha.surface1};
+$overlay0: ${mocha.overlay0};
+$text: ${mocha.text};
+$subtext0: ${mocha.subtext0};
+$blue: ${mocha.blue};
+$sapphire: ${mocha.sapphire};
+$sky: ${mocha.sky};
+$teal: ${mocha.teal};
+$green: ${mocha.green};
+$yellow: ${mocha.yellow};
+$peach: ${mocha.peach};
+$red: ${mocha.red};
+$mauve: ${mocha.mauve};
+
+// -----------------------------------------------------------------------------
+// Common Styles
+// -----------------------------------------------------------------------------
+
+* {
+  font-family: "JetBrainsMono Nerd Font", "Symbols Nerd Font", sans-serif;
+  font-size: 13px;
+  color: $text;
+}
+
+// -----------------------------------------------------------------------------
+// Top Bar Indicators
+// -----------------------------------------------------------------------------
+
+.device-indicator {
+  padding: 0 4px;
+  margin: 0 2px;
+  border-radius: 6px;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($surface0, 0.5);
+  }
+}
+
+.indicator-box {
+  padding: 4px 6px;
+}
+
+.indicator-icon {
+  font-size: 16px;
+  min-width: 20px;
+
+  &.muted {
+    color: $subtext0;
+  }
+
+  &.connected {
+    color: $teal;
+  }
+
+  &.disabled {
+    color: $overlay0;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Expanded Panels
+// -----------------------------------------------------------------------------
+
+.expanded-panel {
+  background: rgba($surface0, 0.95);
+  border: 1px solid rgba($mauve, 0.3);
+  border-radius: 12px;
+  padding: 12px;
+  margin-left: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.volume-panel {
+  min-width: 200px;
+}
+
+.bluetooth-panel {
+  min-width: 220px;
+}
+
+.brightness-panel {
+  min-width: 200px;
+}
+
+.battery-panel {
+  min-width: 180px;
+}
+
+// -----------------------------------------------------------------------------
+// Sliders
+// -----------------------------------------------------------------------------
+
+.device-slider {
+  min-width: 120px;
+
+  trough {
+    background: rgba($overlay0, 0.3);
+    border-radius: 4px;
+    min-height: 6px;
+
+    highlight {
+      background: $blue;
+      border-radius: 4px;
+    }
+  }
+
+  slider {
+    background: $text;
+    border-radius: 50%;
+    min-width: 14px;
+    min-height: 14px;
+    margin: -4px 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+
+    &:hover {
+      background: $mauve;
+    }
+  }
+}
+
+.brightness-slider trough highlight {
+  background: $yellow;
+}
+
+.keyboard-slider trough highlight {
+  background: $peach;
+}
+
+.volume-slider trough highlight {
+  background: $blue;
+}
+
+// -----------------------------------------------------------------------------
+// Buttons
+// -----------------------------------------------------------------------------
+
+.panel-button {
+  background: rgba($surface1, 0.5);
+  border: 1px solid rgba($overlay0, 0.3);
+  border-radius: 6px;
+  padding: 4px 8px;
+  min-width: 28px;
+  min-height: 28px;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($blue, 0.2);
+    border-color: $blue;
+  }
+}
+
+.close-btn {
+  color: $subtext0;
+
+  &:hover {
+    color: $red;
+    background: rgba($red, 0.15);
+    border-color: $red;
+  }
+}
+
+.mute-toggle {
+  &.active {
+    background: rgba($red, 0.2);
+    border-color: $red;
+    color: $red;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Toggle Switch
+// -----------------------------------------------------------------------------
+
+.toggle-switch {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.toggle-track {
+  background: rgba($overlay0, 0.4);
+  border-radius: 12px;
+  min-width: 44px;
+  min-height: 24px;
+  padding: 2px;
+  transition: all 200ms ease;
+}
+
+.toggle-thumb {
+  background: $text;
+  border-radius: 50%;
+  min-width: 20px;
+  min-height: 20px;
+  margin-left: 0;
+  transition: all 200ms ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-switch.active {
+  .toggle-track {
+    background: rgba($teal, 0.6);
+  }
+
+  .toggle-thumb {
+    margin-left: 20px;
+    background: $teal;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Device List
+// -----------------------------------------------------------------------------
+
+.device-list {
+  margin-top: 8px;
+}
+
+.device-item {
+  background: rgba($surface1, 0.3);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 8px 10px;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($surface1, 0.6);
+    border-color: rgba($blue, 0.3);
+  }
+
+  &.connected {
+    border-color: rgba($teal, 0.5);
+    background: rgba($teal, 0.1);
+  }
+}
+
+.device-icon {
+  font-size: 18px;
+  min-width: 24px;
+  color: $subtext0;
+
+  .connected & {
+    color: $teal;
+  }
+}
+
+.device-name {
+  font-weight: 500;
+}
+
+.device-mac {
+  font-size: 10px;
+  color: $subtext0;
+}
+
+.device-status {
+  font-size: 11px;
+  color: $teal;
+  margin-left: auto;
+}
+
+.device-battery {
+  font-size: 11px;
+  color: $green;
+}
+
+// -----------------------------------------------------------------------------
+// Battery Indicator
+// -----------------------------------------------------------------------------
+
+.battery-indicator {
+  .battery-percent {
+    font-size: 11px;
+    color: $subtext0;
+    margin-left: 4px;
+  }
+}
+
+.battery-icon {
+  &.critical { color: $red; }
+  &.low { color: $yellow; }
+  &.normal { color: $text; }
+  &.full { color: $green; }
+  &.charging { color: $teal; }
+}
+
+// -----------------------------------------------------------------------------
+// Panel Rows
+// -----------------------------------------------------------------------------
+
+.panel-row {
+  padding: 4px 0;
+}
+
+.panel-label {
+  color: $subtext0;
+  min-width: 60px;
+}
+
+.panel-value {
+  font-weight: 500;
+}
+
+.slider-row {
+  padding: 4px 0;
+}
+
+.slider-label {
+  color: $subtext0;
+  min-width: 24px;
+  font-size: 16px;
+}
+
+.slider-value {
+  color: $subtext0;
+  font-size: 11px;
+  min-width: 36px;
+  text-align: right;
+}
+
+// -----------------------------------------------------------------------------
+// Devices Tab (Monitoring Panel)
+// -----------------------------------------------------------------------------
+
+.devices-tab {
+  padding: 16px;
+}
+
+.devices-content {
+  padding: 0;
+}
+
+.devices-section {
+  background: rgba($surface0, 0.6);
+  border: 1px solid rgba($overlay0, 0.3);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.section-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: $blue;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba($overlay0, 0.2);
+}
+
+.section-content {
+  padding: 4px 0;
+}
+
+// Section-specific colors
+.audio-section .section-title { color: $blue; }
+.display-section .section-title { color: $yellow; }
+.bluetooth-section .section-title { color: $sapphire; }
+.power-section .section-title { color: $green; }
+.thermal-section .section-title { color: $peach; }
+.network-section .section-title { color: $teal; }
+
+// -----------------------------------------------------------------------------
+// Device Selector
+// -----------------------------------------------------------------------------
+
+.device-selector {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba($overlay0, 0.2);
+}
+
+.device-option {
+  background: rgba($surface1, 0.3);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 8px 12px;
+  text-align: left;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($surface1, 0.6);
+    border-color: rgba($blue, 0.3);
+  }
+
+  &.active {
+    border-color: $blue;
+    background: rgba($blue, 0.15);
+  }
+}
+
+.device-type-icon {
+  font-size: 16px;
+  color: $subtext0;
+  min-width: 24px;
+}
+
+// -----------------------------------------------------------------------------
+// Battery Section (Devices Tab)
+// -----------------------------------------------------------------------------
+
+.battery-status {
+  padding: 8px 0;
+}
+
+.battery-icon {
+  font-size: 32px;
+}
+
+.battery-info {
+  margin-left: 4px;
+}
+
+.battery-percent-large {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.battery-state {
+  font-size: 12px;
+  color: $subtext0;
+}
+
+.time-remaining {
+  font-size: 14px;
+  color: $subtext0;
+  padding: 4px 12px;
+  background: rgba($surface1, 0.4);
+  border-radius: 8px;
+}
+
+.battery-details {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: rgba($surface1, 0.3);
+  border-radius: 8px;
+}
+
+.detail-item {
+  flex-direction: column;
+}
+
+.detail-label {
+  font-size: 10px;
+  color: $subtext0;
+  text-transform: uppercase;
+}
+
+.detail-value {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+// -----------------------------------------------------------------------------
+// Power Profiles
+// -----------------------------------------------------------------------------
+
+.power-profiles {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba($overlay0, 0.2);
+}
+
+.profile-btn {
+  background: rgba($surface1, 0.3);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 8px 12px;
+  flex: 1;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($surface1, 0.6);
+    border-color: rgba($mauve, 0.3);
+  }
+
+  &.active {
+    border-color: $mauve;
+    background: rgba($mauve, 0.15);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Thermal Section
+// -----------------------------------------------------------------------------
+
+.thermal-row {
+  padding: 8px 0;
+}
+
+.thermal-icon {
+  font-size: 28px;
+
+  &.cool { color: $teal; }
+  &.warm { color: $yellow; }
+  &.hot { color: $peach; }
+  &.critical { color: $red; }
+}
+
+.thermal-info {
+  margin-left: 4px;
+}
+
+.thermal-label {
+  font-size: 12px;
+  color: $subtext0;
+}
+
+.thermal-value {
+  font-size: 18px;
+  font-weight: 600;
+
+  &.cool { color: $teal; }
+  &.warm { color: $yellow; }
+  &.hot { color: $peach; }
+  &.critical { color: $red; }
+}
+
+.thermal-bar {
+  min-width: 100px;
+  margin-left: auto;
+
+  trough {
+    background: rgba($overlay0, 0.3);
+    border-radius: 4px;
+    min-height: 8px;
+
+    progress {
+      border-radius: 4px;
+    }
+  }
+
+  &.cool trough progress { background: $teal; }
+  &.warm trough progress { background: $yellow; }
+  &.hot trough progress { background: $peach; }
+  &.critical trough progress { background: $red; }
+}
+
+.fan-row {
+  padding: 4px 0;
+  margin-top: 4px;
+}
+
+.fan-icon {
+  font-size: 16px;
+  color: $subtext0;
+}
+
+.fan-label {
+  color: $subtext0;
+  font-size: 12px;
+}
+
+.fan-value {
+  font-size: 14px;
+  margin-left: auto;
+}
+
+// -----------------------------------------------------------------------------
+// Network Section
+// -----------------------------------------------------------------------------
+
+.network-row {
+  padding: 8px 0;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid rgba($overlay0, 0.15);
+  }
+}
+
+.network-icon {
+  font-size: 20px;
+  color: $subtext0;
+  min-width: 28px;
+
+  &.connected {
+    color: $teal;
+  }
+
+  &.disconnected {
+    color: $overlay0;
+  }
+}
+
+.network-info {
+  margin-left: 4px;
+}
+
+.network-type {
+  font-size: 11px;
+  color: $subtext0;
+  text-transform: uppercase;
+}
+
+.network-value {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.signal-strength {
+  font-size: 12px;
+  color: $teal;
+  margin-left: auto;
+}
+
+// -----------------------------------------------------------------------------
+// Connect Button
+// -----------------------------------------------------------------------------
+
+.connect-btn {
+  background: rgba($blue, 0.15);
+  border: 1px solid rgba($blue, 0.3);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 11px;
+  margin-left: auto;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($blue, 0.3);
+    border-color: $blue;
+  }
+
+  .connected & {
+    background: rgba($red, 0.15);
+    border-color: rgba($red, 0.3);
+    color: $red;
+
+    &:hover {
+      background: rgba($red, 0.3);
+      border-color: $red;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Mute Button (Devices Tab)
+// -----------------------------------------------------------------------------
+
+.mute-btn {
+  background: rgba($surface1, 0.5);
+  border: 1px solid rgba($overlay0, 0.3);
+  border-radius: 6px;
+  padding: 4px 8px;
+  min-width: 28px;
+  transition: all 150ms ease;
+
+  &:hover {
+    background: rgba($blue, 0.2);
+    border-color: $blue;
+  }
+
+  &.muted {
+    background: rgba($red, 0.2);
+    border-color: $red;
+    color: $red;
+  }
+}
+''

--- a/home-modules/desktop/eww-device-controls/eww.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/eww.yuck.nix
@@ -1,0 +1,124 @@
+# Eww Widget Definitions for Device Controls
+# Feature 116: Unified device control widgets
+#
+# This file composes modular widget definitions from:
+# - widgets/variables.yuck.nix - State and polling definitions
+# - widgets/indicators/*.yuck.nix - Top bar indicator widgets
+# - widgets/sections/*.yuck.nix - Devices tab section widgets
+#
+{ config, lib, pkgs, mocha, isLaptop, isRyzen, isThinkPad, isM1, isHeadless, scriptsDir, ... }:
+
+let
+  cfg = config.programs.eww-device-controls;
+
+  # Common arguments passed to all widget modules
+  widgetArgs = { inherit cfg scriptsDir; };
+
+  # Import modular widget definitions
+  variablesYuck = import ./widgets/variables.yuck.nix (widgetArgs // { inherit isLaptop; });
+
+  # Top bar indicators
+  volumeIndicator = import ./widgets/indicators/volume.yuck.nix widgetArgs;
+  bluetoothIndicator = import ./widgets/indicators/bluetooth.yuck.nix widgetArgs;
+  brightnessIndicator = import ./widgets/indicators/brightness.yuck.nix widgetArgs;
+  batteryIndicator = import ./widgets/indicators/battery.yuck.nix widgetArgs;
+
+  # Devices tab sections
+  audioSection = import ./widgets/sections/audio.yuck.nix widgetArgs;
+  displaySection = import ./widgets/sections/display.yuck.nix widgetArgs;
+  bluetoothSection = import ./widgets/sections/bluetooth.yuck.nix widgetArgs;
+  powerSection = import ./widgets/sections/power.yuck.nix widgetArgs;
+  thermalSection = import ./widgets/sections/thermal.yuck.nix widgetArgs;
+  networkSection = import ./widgets/sections/network.yuck.nix widgetArgs;
+
+in
+''
+; =============================================================================
+; Feature 116: Eww Device Controls
+; =============================================================================
+; Modular device control system with:
+; - Top bar indicators with expandable panels (volume, brightness, bluetooth, battery)
+; - Devices tab for monitoring panel (comprehensive dashboard)
+;
+; Structure:
+; - Variables/polling from widgets/variables.yuck.nix
+; - Indicators from widgets/indicators/*.yuck.nix
+; - Sections from widgets/sections/*.yuck.nix
+; =============================================================================
+
+${variablesYuck}
+
+; =============================================================================
+; Top Bar Indicators (Tier 1: Quick Access)
+; =============================================================================
+
+${volumeIndicator}
+
+${bluetoothIndicator}
+
+${if isLaptop then brightnessIndicator else ""}
+
+${if isLaptop then batteryIndicator else ""}
+
+; -----------------------------------------------------------------------------
+; Combined Device Controls Widget (for top bar integration)
+; -----------------------------------------------------------------------------
+
+(defwidget device-controls []
+  (box :class "device-controls" :spacing 4
+    (volume-indicator)
+    ${if cfg.showBluetooth then "(bluetooth-indicator)" else ""}
+    ${if isLaptop then "(brightness-indicator)" else ""}
+    ${if isLaptop then "(battery-indicator)" else ""}))
+
+; -----------------------------------------------------------------------------
+; Click-Outside Handler
+; -----------------------------------------------------------------------------
+; Closes all expanded panels when clicking outside
+
+(defwidget device-controls-wrapper []
+  (eventbox
+    :onclick "eww update volume_expanded=false brightness_expanded=false bluetooth_expanded=false battery_expanded=false"
+    :class "device-controls-wrapper"
+    (device-controls)))
+
+; =============================================================================
+; Devices Tab Sections (Tier 2: Comprehensive Dashboard for Monitoring Panel)
+; =============================================================================
+
+${audioSection}
+
+${if isLaptop then displaySection else ""}
+
+${bluetoothSection}
+
+${if isLaptop then powerSection else ""}
+
+${thermalSection}
+
+${if cfg.showNetwork then networkSection else ""}
+
+; -----------------------------------------------------------------------------
+; Main Devices Tab Widget
+; -----------------------------------------------------------------------------
+
+(defwidget devices-tab []
+  (scroll :class "devices-tab" :vscroll true :hscroll false
+    (box :class "devices-content" :orientation "v" :spacing 16
+      (devices-audio-section)
+      ${if isLaptop then "(devices-display-section)" else ""}
+      (devices-bluetooth-section)
+      ${if isLaptop then "(devices-power-section)" else ""}
+      (devices-thermal-section)
+      ${if cfg.showNetwork then "(devices-network-section)" else ""})))
+
+; -----------------------------------------------------------------------------
+; Section List for Navigation
+; -----------------------------------------------------------------------------
+
+(defvar devices_sections [${if isLaptop then ''
+  "audio" "display" "bluetooth" "power" "thermal"${if cfg.showNetwork then '' "network"'' else ""}
+'' else ''
+  "audio" "bluetooth" "thermal"${if cfg.showNetwork then '' "network"'' else ""}
+''}])
+''

--- a/home-modules/desktop/eww-device-controls/scripts/bluetooth-control.sh
+++ b/home-modules/desktop/eww-device-controls/scripts/bluetooth-control.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Bluetooth control wrapper for Eww onclick handlers
+# Feature 116: Unified device controls
+#
+# Usage: bluetooth-control.sh ACTION [TARGET]
+#
+# Actions:
+#   get               Get bluetooth state (JSON)
+#   power [on|off|toggle]  Control adapter power
+#   connect MAC       Connect to device
+#   disconnect MAC    Disconnect device
+#   scan [on|off]     Control scanning
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - Bluetooth unavailable
+
+set -euo pipefail
+
+ACTION="${1:-get}"
+TARGET="${2:-toggle}"
+
+error_json() {
+    echo "{\"error\": true, \"message\": \"$1\", \"code\": \"$2\"}"
+    exit "${3:-1}"
+}
+
+# Check if bluetooth is available
+if ! command -v bluetoothctl &>/dev/null; then
+    error_json "bluetoothctl not found" "BT_UNAVAILABLE" 2
+fi
+
+# Check if adapter exists
+if ! bluetoothctl show &>/dev/null; then
+    error_json "No Bluetooth adapter found" "BT_UNAVAILABLE" 2
+fi
+
+case "$ACTION" in
+    get)
+        # Get bluetooth state as JSON
+        output=$(bluetoothctl show 2>/dev/null) || error_json "Failed to get bluetooth status" "BLUETOOTHCTL_ERROR"
+
+        enabled="false"
+        scanning="false"
+
+        if echo "$output" | grep -q "Powered: yes"; then
+            enabled="true"
+        fi
+
+        if echo "$output" | grep -q "Discovering: yes"; then
+            scanning="true"
+        fi
+
+        # Get paired devices
+        devices_json="["
+        first=true
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^Device[[:space:]]([0-9A-Fa-f:]+)[[:space:]](.+)$ ]]; then
+                mac="${BASH_REMATCH[1]}"
+                name="${BASH_REMATCH[2]}"
+
+                # Get device info
+                info=$(bluetoothctl info "$mac" 2>/dev/null) || continue
+
+                connected="false"
+                if echo "$info" | grep -q "Connected: yes"; then
+                    connected="true"
+                fi
+
+                # Get device type icon
+                icon="󰂯"
+                name_lower=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+                if [[ "$name_lower" == *"airpods"* ]] || [[ "$name_lower" == *"headphone"* ]] || [[ "$name_lower" == *"buds"* ]]; then
+                    icon="󰋋"
+                elif [[ "$name_lower" == *"keyboard"* ]]; then
+                    icon="󰌌"
+                elif [[ "$name_lower" == *"mouse"* ]] || [[ "$name_lower" == *"trackpad"* ]]; then
+                    icon="󰍽"
+                elif [[ "$name_lower" == *"speaker"* ]]; then
+                    icon="󰓃"
+                fi
+
+                if [[ "$first" == "true" ]]; then
+                    first=false
+                else
+                    devices_json+=","
+                fi
+
+                # Escape name for JSON
+                escaped_name=$(echo "$name" | sed 's/"/\\"/g')
+                devices_json+="{\"mac\": \"$mac\", \"name\": \"$escaped_name\", \"connected\": $connected, \"icon\": \"$icon\"}"
+            fi
+        done < <(bluetoothctl devices Paired 2>/dev/null)
+        devices_json+="]"
+
+        echo "{\"enabled\": $enabled, \"scanning\": $scanning, \"devices\": $devices_json}"
+        ;;
+
+    power)
+        # Control adapter power
+        case "$TARGET" in
+            on)
+                bluetoothctl power on &>/dev/null || error_json "Failed to power on bluetooth" "BLUETOOTHCTL_ERROR"
+                ;;
+            off)
+                bluetoothctl power off &>/dev/null || error_json "Failed to power off bluetooth" "BLUETOOTHCTL_ERROR"
+                ;;
+            toggle)
+                current=$(bluetoothctl show 2>/dev/null | grep "Powered:" | awk '{print $2}')
+                if [[ "$current" == "yes" ]]; then
+                    bluetoothctl power off &>/dev/null || error_json "Failed to power off bluetooth" "BLUETOOTHCTL_ERROR"
+                else
+                    bluetoothctl power on &>/dev/null || error_json "Failed to power on bluetooth" "BLUETOOTHCTL_ERROR"
+                fi
+                ;;
+            *)
+                error_json "Invalid power target: $TARGET (use on|off|toggle)" "INVALID_VALUE"
+                ;;
+        esac
+        ;;
+
+    connect)
+        # Connect to device
+        mac="$TARGET"
+        if [[ ! "$mac" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+            error_json "Invalid MAC address: $mac" "INVALID_VALUE"
+        fi
+
+        # Ensure bluetooth is powered on
+        bluetoothctl power on &>/dev/null
+
+        # Connect (with timeout)
+        timeout 10 bluetoothctl connect "$mac" &>/dev/null || error_json "Failed to connect to $mac" "CONNECT_FAILED"
+        ;;
+
+    disconnect)
+        # Disconnect from device
+        mac="$TARGET"
+        if [[ ! "$mac" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+            error_json "Invalid MAC address: $mac" "INVALID_VALUE"
+        fi
+
+        bluetoothctl disconnect "$mac" &>/dev/null || error_json "Failed to disconnect from $mac" "DISCONNECT_FAILED"
+        ;;
+
+    scan)
+        # Control scanning
+        case "$TARGET" in
+            on)
+                bluetoothctl scan on &>/dev/null &
+                disown
+                ;;
+            off)
+                bluetoothctl scan off 2>/dev/null || true
+                ;;
+            *)
+                error_json "Invalid scan target: $TARGET (use on|off)" "INVALID_VALUE"
+                ;;
+        esac
+        ;;
+
+    *)
+        error_json "Unknown action: $ACTION" "INVALID_ACTION"
+        ;;
+esac

--- a/home-modules/desktop/eww-device-controls/scripts/brightness-control.sh
+++ b/home-modules/desktop/eww-device-controls/scripts/brightness-control.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Brightness control wrapper for Eww onclick handlers
+# Feature 116: Unified device controls
+#
+# Usage: brightness-control.sh ACTION [VALUE] [--device DEVICE]
+#
+# Actions:
+#   get           Get current brightness (JSON)
+#   set VALUE     Set brightness to VALUE (0-100)
+#   up [STEP]     Increase by STEP (default: 5)
+#   down [STEP]   Decrease by STEP (default: 5)
+#
+# Options:
+#   --device DEVICE  Target device (display|keyboard)
+#                    Default: display
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - Device unavailable
+
+set -euo pipefail
+
+ACTION="${1:-get}"
+VALUE="${2:-5}"
+DEVICE_TYPE="display"
+
+# Save original positional args before parsing
+ORIG_VALUE="$VALUE"
+
+# Parse --device flag from args 3+
+shift 2 2>/dev/null || true
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --device)
+            DEVICE_TYPE="${2:-display}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Restore VALUE
+VALUE="$ORIG_VALUE"
+
+# Find brightness device
+find_device() {
+    local type="$1"
+
+    if [[ "$type" == "display" ]]; then
+        # Find display backlight device
+        if [[ -d /sys/class/backlight ]]; then
+            for device in /sys/class/backlight/*; do
+                if [[ -d "$device" ]]; then
+                    basename "$device"
+                    return 0
+                fi
+            done
+        fi
+    elif [[ "$type" == "keyboard" ]]; then
+        # Find keyboard backlight device
+        if [[ -d /sys/class/leds ]]; then
+            for device in /sys/class/leds/*kbd*; do
+                if [[ -d "$device" ]]; then
+                    basename "$device"
+                    return 0
+                fi
+            done
+            for device in /sys/class/leds/*keyboard*; do
+                if [[ -d "$device" ]]; then
+                    basename "$device"
+                    return 0
+                fi
+            done
+        fi
+    fi
+
+    return 1
+}
+
+error_json() {
+    echo "{\"error\": true, \"message\": \"$1\", \"code\": \"$2\"}"
+    exit "${3:-1}"
+}
+
+# Get device name
+DEVICE=$(find_device "$DEVICE_TYPE") || error_json "No $DEVICE_TYPE brightness device found" "BRIGHTNESS_UNAVAILABLE" 2
+
+case "$ACTION" in
+    get)
+        # Get current brightness as JSON using machine-readable format
+        # Format: device,class,current,percent,max
+        output=$(brightnessctl -d "$DEVICE" -m 2>/dev/null) || error_json "Failed to get brightness" "BRIGHTNESSCTL_ERROR"
+        brightness=$(echo "$output" | cut -d',' -f4 | tr -d '%')
+        max=$(echo "$output" | cut -d',' -f5)
+
+        echo "{\"brightness\": $brightness, \"device\": \"$DEVICE\", \"max\": $max}"
+        ;;
+
+    set)
+        # Set brightness (0-100)
+        if [[ ! "$VALUE" =~ ^[0-9]+$ ]] || [[ "$VALUE" -lt 0 ]] || [[ "$VALUE" -gt 100 ]]; then
+            error_json "Invalid brightness value: $VALUE (must be 0-100)" "INVALID_VALUE"
+        fi
+
+        # Set minimum of 5% to avoid completely dark screen
+        if [[ "$DEVICE_TYPE" == "display" ]] && [[ "$VALUE" -lt 5 ]]; then
+            VALUE=5
+        fi
+
+        brightnessctl -d "$DEVICE" set "${VALUE}%" 2>/dev/null || error_json "Failed to set brightness" "BRIGHTNESSCTL_ERROR"
+        ;;
+
+    up)
+        # Increase brightness by STEP (default 5)
+        step="${VALUE:-5}"
+        brightnessctl -d "$DEVICE" set "${step}%+" 2>/dev/null || error_json "Failed to increase brightness" "BRIGHTNESSCTL_ERROR"
+        ;;
+
+    down)
+        # Decrease brightness by STEP (default 5)
+        step="${VALUE:-5}"
+        # Prevent going below 5% for display
+        if [[ "$DEVICE_TYPE" == "display" ]]; then
+            current=$(brightnessctl -d "$DEVICE" -m 2>/dev/null | cut -d',' -f4 | tr -d '%')
+            new_val=$((current - step))
+            if [[ $new_val -lt 5 ]]; then
+                brightnessctl -d "$DEVICE" set "5%" 2>/dev/null || error_json "Failed to set brightness" "BRIGHTNESSCTL_ERROR"
+            else
+                brightnessctl -d "$DEVICE" set "${step}%-" 2>/dev/null || error_json "Failed to decrease brightness" "BRIGHTNESSCTL_ERROR"
+            fi
+        else
+            brightnessctl -d "$DEVICE" set "${step}%-" 2>/dev/null || error_json "Failed to decrease brightness" "BRIGHTNESSCTL_ERROR"
+        fi
+        ;;
+
+    *)
+        error_json "Unknown action: $ACTION" "INVALID_ACTION"
+        ;;
+esac

--- a/home-modules/desktop/eww-device-controls/scripts/device-backend.py
+++ b/home-modules/desktop/eww-device-controls/scripts/device-backend.py
@@ -1,0 +1,1004 @@
+#!/usr/bin/env python3
+"""Unified device backend for Eww widgets.
+
+Feature 116: Provides device state queries for volume, brightness, bluetooth,
+battery, thermal, and network status.
+
+Usage:
+    device-backend.py [--mode MODE] [--listen]
+
+Options:
+    --mode MODE    Query mode: full | volume | brightness | bluetooth | battery | thermal | network
+    --listen       Stream updates continuously (for deflisten)
+
+Exit Codes:
+    0 - Success
+    1 - Invalid arguments
+    2 - Hardware detection failed
+    3 - Permission denied
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Optional
+
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+@dataclass
+class AudioDevice:
+    """Audio output device."""
+    id: int
+    name: str
+    type: str  # "speaker" | "headphones" | "bluetooth"
+    active: bool
+
+
+@dataclass
+class VolumeState:
+    """Audio volume state."""
+    volume: int  # 0-100
+    muted: bool
+    icon: str
+    current_device: str
+    devices: list = field(default_factory=list)
+
+
+@dataclass
+class BrightnessState:
+    """Brightness state for displays and keyboard."""
+    display: int  # 0-100
+    display_device: str
+    keyboard: Optional[int] = None  # 0-100 or None
+    keyboard_device: Optional[str] = None
+
+
+@dataclass
+class BluetoothDevice:
+    """Paired Bluetooth device."""
+    mac: str
+    name: str
+    type: str  # "headphones" | "keyboard" | "mouse" | "speaker" | "other"
+    connected: bool
+    battery: Optional[int] = None
+    icon: str = "󰂯"
+
+
+@dataclass
+class BluetoothState:
+    """Bluetooth adapter and device state."""
+    enabled: bool
+    scanning: bool
+    devices: list = field(default_factory=list)
+
+
+@dataclass
+class BatteryState:
+    """Battery status."""
+    percentage: int  # 0-100
+    state: str  # "charging" | "discharging" | "full" | "empty"
+    time_remaining: Optional[str] = None
+    icon: str = "󰁹"
+    level: str = "normal"  # "critical" | "low" | "normal" | "full"
+    health: Optional[int] = None
+    cycles: Optional[int] = None
+    power_draw: Optional[float] = None
+
+
+@dataclass
+class PowerProfileState:
+    """Power profile status."""
+    current: str  # "performance" | "balanced" | "power-saver"
+    on_ac: bool
+    available: list = field(default_factory=list)
+    icon: str = "󰾅"
+
+
+@dataclass
+class ThermalState:
+    """Thermal monitoring state."""
+    cpu_temp: int  # Celsius
+    cpu_temp_max: int
+    level: str  # "cool" | "warm" | "hot" | "critical"
+    icon: str = "󰔐"
+    fan_speed: Optional[int] = None  # RPM
+    fan_speed_max: Optional[int] = None
+
+
+@dataclass
+class NetworkState:
+    """Network connection state."""
+    wifi_enabled: bool
+    wifi_connected: bool
+    wifi_ssid: Optional[str] = None
+    wifi_signal: Optional[int] = None  # 0-100
+    wifi_icon: str = "󰤭"
+    tailscale_connected: bool = False
+    tailscale_ip: Optional[str] = None
+
+
+@dataclass
+class HardwareCapabilities:
+    """Hardware detection flags."""
+    has_battery: bool = False
+    has_brightness: bool = False
+    has_keyboard_backlight: bool = False
+    has_bluetooth: bool = False
+    has_wifi: bool = False
+    has_thermal_sensors: bool = False
+    has_fan_control: bool = False
+    has_power_profiles: bool = False
+    hostname: str = ""
+    is_laptop: bool = False
+
+
+@dataclass
+class DeviceState:
+    """Complete device state."""
+    volume: VolumeState = None
+    brightness: Optional[BrightnessState] = None
+    bluetooth: BluetoothState = None
+    battery: Optional[BatteryState] = None
+    power_profile: Optional[PowerProfileState] = None
+    thermal: ThermalState = None
+    network: NetworkState = None
+    hardware: HardwareCapabilities = None
+
+
+# =============================================================================
+# Hardware Detection
+# =============================================================================
+
+def detect_hardware() -> HardwareCapabilities:
+    """Detect available hardware capabilities."""
+    caps = HardwareCapabilities()
+
+    # Hostname
+    caps.hostname = os.uname().nodename
+
+    # Battery detection
+    battery_path = Path("/sys/class/power_supply")
+    if battery_path.exists():
+        caps.has_battery = any(battery_path.glob("BAT*"))
+
+    # Brightness detection
+    backlight_path = Path("/sys/class/backlight")
+    if backlight_path.exists():
+        caps.has_brightness = any(backlight_path.iterdir())
+
+    # Keyboard backlight detection
+    leds_path = Path("/sys/class/leds")
+    if leds_path.exists():
+        caps.has_keyboard_backlight = any(
+            p for p in leds_path.iterdir()
+            if "kbd" in p.name.lower() or "keyboard" in p.name.lower()
+        )
+
+    # Bluetooth detection
+    bt_path = Path("/sys/class/bluetooth")
+    caps.has_bluetooth = bt_path.exists() and any(bt_path.iterdir())
+
+    # WiFi detection
+    net_path = Path("/sys/class/net")
+    if net_path.exists():
+        caps.has_wifi = any(
+            p for p in net_path.iterdir()
+            if p.name.startswith("wl")
+        )
+
+    # Thermal sensors detection
+    hwmon_path = Path("/sys/class/hwmon")
+    caps.has_thermal_sensors = hwmon_path.exists() and any(hwmon_path.iterdir())
+
+    # Fan detection (check for fan inputs in hwmon)
+    if caps.has_thermal_sensors:
+        for hwmon in hwmon_path.iterdir():
+            if any(hwmon.glob("fan*_input")):
+                caps.has_fan_control = True
+                break
+
+    # Power profiles detection
+    caps.has_power_profiles = (
+        subprocess.run(["which", "powerprofilesctl"], capture_output=True).returncode == 0 or
+        subprocess.run(["which", "tlp-stat"], capture_output=True).returncode == 0
+    )
+
+    # Is laptop (derived from battery)
+    caps.is_laptop = caps.has_battery
+
+    return caps
+
+
+# =============================================================================
+# Volume Query Functions
+# =============================================================================
+
+def get_volume_icon(volume: int, muted: bool) -> str:
+    """Get volume icon based on level and mute state."""
+    if muted or volume == 0:
+        return "󰝟"
+    elif volume <= 33:
+        return "󰕿"
+    elif volume <= 66:
+        return "󰖀"
+    else:
+        return "󰕾"
+
+
+def get_audio_devices() -> list[AudioDevice]:
+    """Get list of audio output devices from WirePlumber."""
+    devices = []
+    try:
+        result = subprocess.run(
+            ["wpctl", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            in_sinks = False
+            for line in result.stdout.split("\n"):
+                if "Sinks:" in line:
+                    in_sinks = True
+                    continue
+                elif in_sinks and line.strip() and not line.startswith(" "):
+                    in_sinks = False
+                    break
+                elif in_sinks and line.strip():
+                    # Parse sink line: " │ * 52. device-name [vol: 0.75]"
+                    active = "*" in line
+                    parts = line.strip().split(".")
+                    if len(parts) >= 2:
+                        try:
+                            device_id = int(parts[0].replace("*", "").replace("│", "").strip())
+                            name_part = ".".join(parts[1:]).split("[")[0].strip()
+                            # Determine device type
+                            name_lower = name_part.lower()
+                            if "bluetooth" in name_lower or "bt" in name_lower:
+                                dev_type = "bluetooth"
+                            elif "headphone" in name_lower or "headset" in name_lower:
+                                dev_type = "headphones"
+                            else:
+                                dev_type = "speaker"
+                            devices.append(AudioDevice(
+                                id=device_id,
+                                name=name_part,
+                                type=dev_type,
+                                active=active
+                            ))
+                        except ValueError:
+                            pass
+    except Exception:
+        pass
+    return devices
+
+
+def query_volume() -> VolumeState:
+    """Query current volume state using wpctl."""
+    volume = 50
+    muted = False
+    current_device = "Unknown"
+
+    try:
+        # Get volume
+        result = subprocess.run(
+            ["wpctl", "get-volume", "@DEFAULT_AUDIO_SINK@"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            output = result.stdout.strip()
+            # Format: "Volume: 0.75" or "Volume: 0.75 [MUTED]"
+            parts = output.split()
+            if len(parts) >= 2:
+                try:
+                    volume = int(float(parts[1]) * 100)
+                except ValueError:
+                    pass
+            muted = "[MUTED]" in output
+    except Exception:
+        pass
+
+    # Get devices
+    devices = get_audio_devices()
+    for dev in devices:
+        if dev.active:
+            current_device = dev.name
+            break
+
+    return VolumeState(
+        volume=volume,
+        muted=muted,
+        icon=get_volume_icon(volume, muted),
+        current_device=current_device,
+        devices=[asdict(d) for d in devices]
+    )
+
+
+# =============================================================================
+# Brightness Query Functions
+# =============================================================================
+
+def find_brightness_device() -> tuple[Optional[str], Optional[str]]:
+    """Find brightness devices (display and keyboard)."""
+    display_device = None
+    keyboard_device = None
+
+    backlight_path = Path("/sys/class/backlight")
+    if backlight_path.exists():
+        for device in backlight_path.iterdir():
+            display_device = device.name
+            break
+
+    leds_path = Path("/sys/class/leds")
+    if leds_path.exists():
+        for device in leds_path.iterdir():
+            if "kbd" in device.name.lower() or "keyboard" in device.name.lower():
+                keyboard_device = device.name
+                break
+
+    return display_device, keyboard_device
+
+
+def query_brightness() -> Optional[BrightnessState]:
+    """Query current brightness state."""
+    display_device, keyboard_device = find_brightness_device()
+
+    if not display_device:
+        return None
+
+    display_brightness = 50
+
+    try:
+        # Get display brightness
+        result = subprocess.run(
+            ["brightnessctl", "-d", display_device, "-P", "get"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            display_brightness = int(result.stdout.strip().replace("%", ""))
+    except Exception:
+        pass
+
+    keyboard_brightness = None
+    if keyboard_device:
+        try:
+            result = subprocess.run(
+                ["brightnessctl", "-d", keyboard_device, "-P", "get"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0:
+                keyboard_brightness = int(result.stdout.strip().replace("%", ""))
+        except Exception:
+            pass
+
+    return BrightnessState(
+        display=display_brightness,
+        display_device=display_device,
+        keyboard=keyboard_brightness,
+        keyboard_device=keyboard_device
+    )
+
+
+# =============================================================================
+# Bluetooth Query Functions
+# =============================================================================
+
+def get_bt_device_icon(device_type: str) -> str:
+    """Get icon for Bluetooth device type."""
+    icons = {
+        "headphones": "󰋋",
+        "keyboard": "󰌌",
+        "mouse": "󰍽",
+        "speaker": "󰓃",
+        "audio-card": "󰋋",
+    }
+    return icons.get(device_type, "󰂯")
+
+
+def infer_bt_device_type(name: str, icon: str) -> str:
+    """Infer Bluetooth device type from name and icon."""
+    name_lower = name.lower()
+    if any(x in name_lower for x in ["airpods", "headphone", "earbuds", "buds", "pods"]):
+        return "headphones"
+    elif any(x in name_lower for x in ["keyboard", "keychron", "hhkb"]):
+        return "keyboard"
+    elif any(x in name_lower for x in ["mouse", "trackpad", "magic"]):
+        return "mouse"
+    elif any(x in name_lower for x in ["speaker", "soundbar", "homepod"]):
+        return "speaker"
+    elif "audio" in icon.lower():
+        return "headphones"
+    return "other"
+
+
+def query_bluetooth() -> BluetoothState:
+    """Query Bluetooth adapter and device state."""
+    enabled = False
+    scanning = False
+    devices = []
+
+    try:
+        # Check if adapter is powered
+        result = subprocess.run(
+            ["bluetoothctl", "show"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            for line in result.stdout.split("\n"):
+                if "Powered:" in line:
+                    enabled = "yes" in line.lower()
+                elif "Discovering:" in line:
+                    scanning = "yes" in line.lower()
+
+        # Get paired devices
+        result = subprocess.run(
+            ["bluetoothctl", "devices", "Paired"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().split("\n"):
+                if line.startswith("Device "):
+                    parts = line.split(" ", 2)
+                    if len(parts) >= 3:
+                        mac = parts[1]
+                        name = parts[2]
+
+                        # Check connection status
+                        connected = False
+                        battery = None
+                        icon = "input-gaming"  # default
+
+                        info_result = subprocess.run(
+                            ["bluetoothctl", "info", mac],
+                            capture_output=True,
+                            text=True,
+                            timeout=5
+                        )
+                        if info_result.returncode == 0:
+                            for info_line in info_result.stdout.split("\n"):
+                                if "Connected:" in info_line:
+                                    connected = "yes" in info_line.lower()
+                                elif "Battery Percentage:" in info_line:
+                                    try:
+                                        battery = int(info_line.split("(")[1].split(")")[0])
+                                    except (IndexError, ValueError):
+                                        pass
+                                elif "Icon:" in info_line:
+                                    icon = info_line.split(":")[1].strip()
+
+                        dev_type = infer_bt_device_type(name, icon)
+                        devices.append(BluetoothDevice(
+                            mac=mac,
+                            name=name,
+                            type=dev_type,
+                            connected=connected,
+                            battery=battery,
+                            icon=get_bt_device_icon(dev_type)
+                        ))
+    except Exception:
+        pass
+
+    return BluetoothState(
+        enabled=enabled,
+        scanning=scanning,
+        devices=[asdict(d) for d in devices]
+    )
+
+
+# =============================================================================
+# Battery Query Functions
+# =============================================================================
+
+def get_battery_icon(percentage: int, state: str) -> str:
+    """Get battery icon based on percentage and state."""
+    if state == "charging":
+        return "󰂄"
+    elif percentage <= 10:
+        return "󰂎"
+    elif percentage <= 20:
+        return "󰁺"
+    elif percentage <= 30:
+        return "󰁻"
+    elif percentage <= 40:
+        return "󰁼"
+    elif percentage <= 50:
+        return "󰁽"
+    elif percentage <= 60:
+        return "󰁾"
+    elif percentage <= 70:
+        return "󰁿"
+    elif percentage <= 80:
+        return "󰂀"
+    elif percentage <= 90:
+        return "󰂁"
+    else:
+        return "󰂂" if state != "full" else "󰁹"
+
+
+def get_battery_level(percentage: int) -> str:
+    """Get battery level category."""
+    if percentage <= 10:
+        return "critical"
+    elif percentage <= 20:
+        return "low"
+    elif percentage >= 95:
+        return "full"
+    else:
+        return "normal"
+
+
+def query_battery() -> Optional[BatteryState]:
+    """Query battery status using UPower."""
+    try:
+        # Find battery device
+        result = subprocess.run(
+            ["upower", "-e"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode != 0:
+            return None
+
+        battery_path = None
+        for line in result.stdout.strip().split("\n"):
+            if "BAT" in line or "battery" in line.lower():
+                battery_path = line.strip()
+                break
+
+        if not battery_path:
+            return None
+
+        # Get battery info
+        result = subprocess.run(
+            ["upower", "-i", battery_path],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode != 0:
+            return None
+
+        percentage = 100
+        state = "full"
+        time_remaining = None
+        health = None
+        power_draw = None
+
+        for line in result.stdout.split("\n"):
+            line = line.strip()
+            if line.startswith("percentage:"):
+                try:
+                    percentage = int(line.split(":")[1].strip().replace("%", ""))
+                except ValueError:
+                    pass
+            elif line.startswith("state:"):
+                state = line.split(":")[1].strip()
+            elif "time to" in line.lower():
+                parts = line.split(":")
+                if len(parts) >= 2:
+                    time_remaining = parts[1].strip()
+            elif line.startswith("capacity:"):
+                try:
+                    health = int(float(line.split(":")[1].strip().replace("%", "")))
+                except ValueError:
+                    pass
+            elif line.startswith("energy-rate:"):
+                try:
+                    power_draw = float(line.split(":")[1].strip().split()[0])
+                except (ValueError, IndexError):
+                    pass
+
+        return BatteryState(
+            percentage=percentage,
+            state=state,
+            time_remaining=time_remaining,
+            icon=get_battery_icon(percentage, state),
+            level=get_battery_level(percentage),
+            health=health,
+            cycles=None,  # UPower doesn't typically provide this
+            power_draw=power_draw
+        )
+    except Exception:
+        return None
+
+
+# =============================================================================
+# Power Profile Query Functions
+# =============================================================================
+
+def get_power_profile_icon(profile: str) -> str:
+    """Get power profile icon."""
+    icons = {
+        "performance": "󱐋",
+        "balanced": "󰾅",
+        "power-saver": "󰾆",
+    }
+    return icons.get(profile, "󰾅")
+
+
+def query_power_profile() -> Optional[PowerProfileState]:
+    """Query power profile status."""
+    try:
+        # Try power-profiles-daemon first
+        result = subprocess.run(
+            ["powerprofilesctl", "get"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            current = result.stdout.strip()
+
+            # Get available profiles
+            list_result = subprocess.run(
+                ["powerprofilesctl", "list"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            available = []
+            if list_result.returncode == 0:
+                for line in list_result.stdout.split("\n"):
+                    line = line.strip()
+                    if line.endswith(":"):
+                        profile = line.rstrip(":").lstrip("* ")
+                        if profile:
+                            available.append(profile)
+
+            # Check AC status
+            on_ac = False
+            ac_path = Path("/sys/class/power_supply/AC")
+            if ac_path.exists():
+                try:
+                    online = (ac_path / "online").read_text().strip()
+                    on_ac = online == "1"
+                except Exception:
+                    pass
+
+            return PowerProfileState(
+                current=current,
+                on_ac=on_ac,
+                available=available or ["balanced"],
+                icon=get_power_profile_icon(current)
+            )
+    except FileNotFoundError:
+        pass
+
+    # Try TLP
+    try:
+        result = subprocess.run(
+            ["tlp-stat", "-s"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            current = "balanced"
+            on_ac = False
+            for line in result.stdout.split("\n"):
+                if "Mode:" in line:
+                    mode = line.split(":")[1].strip().lower()
+                    if "ac" in mode:
+                        current = "performance"
+                        on_ac = True
+                    elif "bat" in mode:
+                        current = "power-saver"
+
+            return PowerProfileState(
+                current=current,
+                on_ac=on_ac,
+                available=["performance", "balanced", "power-saver"],
+                icon=get_power_profile_icon(current)
+            )
+    except FileNotFoundError:
+        pass
+
+    return None
+
+
+# =============================================================================
+# Thermal Query Functions
+# =============================================================================
+
+def get_thermal_icon(level: str) -> str:
+    """Get thermal icon based on level."""
+    icons = {
+        "cool": "󰔏",
+        "warm": "󰔐",
+        "hot": "󰸁",
+        "critical": "󱗗",
+    }
+    return icons.get(level, "󰔐")
+
+
+def get_thermal_level(temp: int) -> str:
+    """Get thermal level category."""
+    if temp < 50:
+        return "cool"
+    elif temp < 70:
+        return "warm"
+    elif temp < 85:
+        return "hot"
+    else:
+        return "critical"
+
+
+def query_thermal() -> ThermalState:
+    """Query thermal sensors using lm_sensors."""
+    cpu_temp = 0
+    cpu_temp_max = 100
+    fan_speed = None
+    fan_speed_max = None
+
+    try:
+        # Use sensors for temperature
+        result = subprocess.run(
+            ["sensors", "-j"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+
+            # Find CPU temperature
+            for chip_name, chip_data in data.items():
+                if isinstance(chip_data, dict):
+                    for sensor_name, sensor_data in chip_data.items():
+                        if isinstance(sensor_data, dict):
+                            # Look for temp inputs
+                            for key, value in sensor_data.items():
+                                if key.endswith("_input") and "temp" in key:
+                                    if value and (cpu_temp == 0 or "core" in sensor_name.lower() or "tctl" in sensor_name.lower()):
+                                        cpu_temp = int(value)
+                                elif key.endswith("_max") and "temp" in key:
+                                    if value:
+                                        cpu_temp_max = int(value)
+                                elif key.endswith("_input") and "fan" in key:
+                                    if value:
+                                        fan_speed = int(value)
+                                elif key.endswith("_max") and "fan" in key:
+                                    if value:
+                                        fan_speed_max = int(value)
+    except Exception:
+        # Fallback: read from thermal zones
+        try:
+            thermal_path = Path("/sys/class/thermal")
+            for zone in thermal_path.glob("thermal_zone*"):
+                temp_file = zone / "temp"
+                if temp_file.exists():
+                    temp_raw = int(temp_file.read_text().strip())
+                    # Temperature is in millidegrees
+                    cpu_temp = temp_raw // 1000
+                    break
+        except Exception:
+            pass
+
+    level = get_thermal_level(cpu_temp)
+
+    return ThermalState(
+        cpu_temp=cpu_temp,
+        cpu_temp_max=cpu_temp_max,
+        level=level,
+        icon=get_thermal_icon(level),
+        fan_speed=fan_speed,
+        fan_speed_max=fan_speed_max
+    )
+
+
+# =============================================================================
+# Network Query Functions
+# =============================================================================
+
+def get_wifi_icon(signal: Optional[int], enabled: bool, connected: bool) -> str:
+    """Get WiFi icon based on signal strength."""
+    if not enabled:
+        return "󰤭"
+    if not connected or signal is None:
+        return "󰤯"
+    elif signal <= 25:
+        return "󰤟"
+    elif signal <= 50:
+        return "󰤢"
+    elif signal <= 75:
+        return "󰤥"
+    else:
+        return "󰤨"
+
+
+def query_network() -> NetworkState:
+    """Query network status using nmcli and tailscale."""
+    wifi_enabled = False
+    wifi_connected = False
+    wifi_ssid = None
+    wifi_signal = None
+    tailscale_connected = False
+    tailscale_ip = None
+
+    try:
+        # Get WiFi status
+        result = subprocess.run(
+            ["nmcli", "-t", "-f", "WIFI", "radio"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            wifi_enabled = result.stdout.strip() == "enabled"
+
+        if wifi_enabled:
+            # Get current WiFi connection
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "active,ssid", "dev", "wifi"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0:
+                for line in result.stdout.strip().split("\n"):
+                    if line.startswith("yes:"):
+                        wifi_connected = True
+                        wifi_ssid = line.split(":")[1] if len(line.split(":")) > 1 else None
+                        break
+
+            # Get signal strength
+            if wifi_connected:
+                result = subprocess.run(
+                    ["nmcli", "-t", "-f", "IN-USE,SIGNAL", "dev", "wifi"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5
+                )
+                if result.returncode == 0:
+                    for line in result.stdout.strip().split("\n"):
+                        if line.startswith("*:"):
+                            try:
+                                wifi_signal = int(line.split(":")[1])
+                            except (ValueError, IndexError):
+                                pass
+                            break
+    except Exception:
+        pass
+
+    # Check Tailscale
+    try:
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            if data.get("Self"):
+                tailscale_connected = data["Self"].get("Online", False)
+                tailscale_ips = data["Self"].get("TailscaleIPs", [])
+                if tailscale_ips:
+                    tailscale_ip = tailscale_ips[0]
+    except Exception:
+        pass
+
+    return NetworkState(
+        wifi_enabled=wifi_enabled,
+        wifi_connected=wifi_connected,
+        wifi_ssid=wifi_ssid,
+        wifi_signal=wifi_signal,
+        wifi_icon=get_wifi_icon(wifi_signal, wifi_enabled, wifi_connected),
+        tailscale_connected=tailscale_connected,
+        tailscale_ip=tailscale_ip
+    )
+
+
+# =============================================================================
+# Main Query Function
+# =============================================================================
+
+def query_device_state(mode: str, hardware: HardwareCapabilities) -> dict:
+    """Query device state based on mode."""
+    if mode == "volume":
+        return asdict(query_volume())
+    elif mode == "brightness":
+        state = query_brightness()
+        return asdict(state) if state else {"error": True, "code": "BRIGHTNESS_UNAVAILABLE"}
+    elif mode == "bluetooth":
+        return asdict(query_bluetooth())
+    elif mode == "battery":
+        state = query_battery()
+        return asdict(state) if state else {"error": True, "code": "BATTERY_UNAVAILABLE"}
+    elif mode == "thermal":
+        return asdict(query_thermal())
+    elif mode == "network":
+        return asdict(query_network())
+    elif mode == "full":
+        # Query all available states
+        result = {
+            "volume": asdict(query_volume()),
+            "bluetooth": asdict(query_bluetooth()),
+            "thermal": asdict(query_thermal()),
+            "network": asdict(query_network()),
+            "hardware": asdict(hardware),
+        }
+
+        # Add optional states based on hardware
+        if hardware.has_brightness:
+            brightness = query_brightness()
+            result["brightness"] = asdict(brightness) if brightness else None
+
+        if hardware.has_battery:
+            battery = query_battery()
+            result["battery"] = asdict(battery) if battery else None
+            power_profile = query_power_profile()
+            result["power_profile"] = asdict(power_profile) if power_profile else None
+        else:
+            result["brightness"] = None
+            result["battery"] = None
+            result["power_profile"] = None
+
+        return result
+    else:
+        return {"error": True, "message": f"Unknown mode: {mode}", "code": "INVALID_MODE"}
+
+
+# =============================================================================
+# Main Entry Point
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="Device backend for Eww widgets")
+    parser.add_argument(
+        "--mode",
+        choices=["full", "volume", "brightness", "bluetooth", "battery", "thermal", "network"],
+        default="full",
+        help="Query mode"
+    )
+    parser.add_argument(
+        "--listen",
+        action="store_true",
+        help="Stream updates continuously"
+    )
+
+    args = parser.parse_args()
+
+    # Detect hardware capabilities once
+    hardware = detect_hardware()
+
+    if args.listen:
+        # Streaming mode for deflisten
+        interval = 1 if args.mode == "volume" else 2
+        while True:
+            try:
+                state = query_device_state(args.mode, hardware)
+                print(json.dumps(state), flush=True)
+                time.sleep(interval)
+            except KeyboardInterrupt:
+                break
+            except Exception as e:
+                print(json.dumps({"error": True, "message": str(e)}), flush=True)
+                time.sleep(interval)
+    else:
+        # Single query mode
+        state = query_device_state(args.mode, hardware)
+        print(json.dumps(state))
+
+
+if __name__ == "__main__":
+    main()

--- a/home-modules/desktop/eww-device-controls/scripts/power-profile-control.sh
+++ b/home-modules/desktop/eww-device-controls/scripts/power-profile-control.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Power profile control wrapper for Eww onclick handlers
+# Feature 116: Unified device controls
+#
+# Usage: power-profile-control.sh ACTION [PROFILE]
+#
+# Actions:
+#   get           Get current profile (JSON)
+#   set PROFILE   Set profile (performance|balanced|power-saver)
+#   cycle         Cycle to next profile
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - Profiles unavailable
+
+set -euo pipefail
+
+ACTION="${1:-get}"
+PROFILE="${2:-}"
+
+PLATFORM_PROFILE="/sys/firmware/acpi/platform_profile"
+PLATFORM_CHOICES="/sys/firmware/acpi/platform_profile_choices"
+
+error_json() {
+    echo "{\"error\": true, \"message\": \"$1\", \"code\": \"$2\"}"
+    exit "${3:-1}"
+}
+
+get_profile_icon() {
+    local profile="$1"
+    case "$profile" in
+        performance) echo "󱐋" ;;
+        balanced) echo "󰾅" ;;
+        power-saver|low-power) echo "󰾆" ;;
+        *) echo "󰾅" ;;
+    esac
+}
+
+# Map platform_profile names to standard names
+normalize_profile() {
+    case "$1" in
+        low-power) echo "power-saver" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+# Map standard names to platform_profile names
+to_platform_profile() {
+    case "$1" in
+        power-saver) echo "low-power" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+# Determine which tool is available
+TOOL=""
+if [[ -f "$PLATFORM_PROFILE" ]]; then
+    TOOL="platform_profile"
+elif command -v powerprofilesctl &>/dev/null; then
+    TOOL="powerprofilesctl"
+else
+    error_json "No power profile tool found" "PROFILES_UNAVAILABLE" 2
+fi
+
+# Check AC status
+get_ac_status() {
+    for ac in /sys/class/power_supply/AC* /sys/class/power_supply/ACAD*; do
+        if [[ -f "$ac/online" ]] && [[ "$(cat "$ac/online")" == "1" ]]; then
+            echo "true"
+            return
+        fi
+    done
+    echo "false"
+}
+
+case "$ACTION" in
+    get)
+        if [[ "$TOOL" == "platform_profile" ]]; then
+            # Read current profile
+            raw_current=$(cat "$PLATFORM_PROFILE" 2>/dev/null) || error_json "Failed to read platform profile" "PROFILE_ERROR"
+            current=$(normalize_profile "$raw_current")
+
+            # Read available profiles
+            if [[ -f "$PLATFORM_CHOICES" ]]; then
+                raw_choices=$(cat "$PLATFORM_CHOICES" 2>/dev/null)
+                profiles=""
+                for p in $raw_choices; do
+                    normalized=$(normalize_profile "$p")
+                    if [[ -n "$profiles" ]]; then
+                        profiles+=","
+                    fi
+                    profiles+="\"$normalized\""
+                done
+                available="[$profiles]"
+            else
+                available="[\"power-saver\", \"balanced\", \"performance\"]"
+            fi
+
+            on_ac=$(get_ac_status)
+            icon=$(get_profile_icon "$current")
+            echo "{\"current\": \"$current\", \"on_ac\": $on_ac, \"available\": $available, \"icon\": \"$icon\"}"
+
+        elif [[ "$TOOL" == "powerprofilesctl" ]]; then
+            current=$(powerprofilesctl get 2>/dev/null) || error_json "Failed to get power profile" "PROFILE_ERROR"
+
+            available="[]"
+            profiles_output=$(powerprofilesctl list 2>/dev/null) || true
+            if [[ -n "$profiles_output" ]]; then
+                profiles=""
+                while IFS= read -r line; do
+                    profile=$(echo "$line" | sed 's/^[* ]*//' | sed 's/:$//' | xargs)
+                    if [[ -n "$profile" ]] && [[ "$profile" != "Profile"* ]]; then
+                        if [[ -n "$profiles" ]]; then
+                            profiles+=","
+                        fi
+                        profiles+="\"$profile\""
+                    fi
+                done < <(echo "$profiles_output" | grep -E "^[* ]*(performance|balanced|power-saver)")
+                available="[$profiles]"
+            fi
+
+            on_ac=$(get_ac_status)
+            icon=$(get_profile_icon "$current")
+            echo "{\"current\": \"$current\", \"on_ac\": $on_ac, \"available\": $available, \"icon\": \"$icon\"}"
+        fi
+        ;;
+
+    set)
+        if [[ -z "$PROFILE" ]]; then
+            error_json "Profile not specified" "INVALID_VALUE"
+        fi
+
+        # Validate profile
+        case "$PROFILE" in
+            performance|balanced|power-saver)
+                ;;
+            *)
+                error_json "Invalid profile: $PROFILE (use performance|balanced|power-saver)" "INVALID_VALUE"
+                ;;
+        esac
+
+        if [[ "$TOOL" == "platform_profile" ]]; then
+            platform_value=$(to_platform_profile "$PROFILE")
+            # Use pkexec for graphical password prompt, or sudo if in terminal
+            if [[ -n "${DISPLAY:-}" ]] || [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+                echo "$platform_value" | pkexec tee "$PLATFORM_PROFILE" >/dev/null 2>&1 || \
+                    error_json "Failed to set profile (authentication required)" "PROFILE_ERROR"
+            else
+                echo "$platform_value" | sudo tee "$PLATFORM_PROFILE" >/dev/null 2>&1 || \
+                    error_json "Failed to set profile (requires sudo)" "PROFILE_ERROR"
+            fi
+
+        elif [[ "$TOOL" == "powerprofilesctl" ]]; then
+            powerprofilesctl set "$PROFILE" 2>/dev/null || error_json "Failed to set power profile" "PROFILE_ERROR"
+        fi
+        ;;
+
+    cycle)
+        # Get current profile and cycle to next
+        if [[ "$TOOL" == "platform_profile" ]]; then
+            raw_current=$(cat "$PLATFORM_PROFILE" 2>/dev/null) || error_json "Failed to read current profile" "PROFILE_ERROR"
+            current=$(normalize_profile "$raw_current")
+        elif [[ "$TOOL" == "powerprofilesctl" ]]; then
+            current=$(powerprofilesctl get 2>/dev/null) || error_json "Failed to get current profile" "PROFILE_ERROR"
+        fi
+
+        case "$current" in
+            power-saver)
+                next="balanced"
+                ;;
+            balanced)
+                next="performance"
+                ;;
+            performance)
+                next="power-saver"
+                ;;
+            *)
+                next="balanced"
+                ;;
+        esac
+
+        # Recursively call set
+        exec "$0" set "$next"
+        ;;
+
+    *)
+        error_json "Unknown action: $ACTION" "INVALID_ACTION"
+        ;;
+esac

--- a/home-modules/desktop/eww-device-controls/scripts/volume-control.sh
+++ b/home-modules/desktop/eww-device-controls/scripts/volume-control.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Volume control wrapper for Eww onclick handlers
+# Feature 116: Unified device controls
+#
+# Usage: volume-control.sh ACTION [VALUE]
+#
+# Actions:
+#   get           Get current volume (JSON)
+#   set VALUE     Set volume to VALUE (0-100)
+#   up [STEP]     Increase volume by STEP (default: 5)
+#   down [STEP]   Decrease volume by STEP (default: 5)
+#   mute          Toggle mute
+#   device ID     Switch to device ID
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+
+set -euo pipefail
+
+ACTION="${1:-get}"
+VALUE="${2:-5}"
+
+error_json() {
+    echo "{\"error\": true, \"message\": \"$1\", \"code\": \"$2\"}"
+    exit 1
+}
+
+case "$ACTION" in
+    get)
+        # Get current volume as JSON
+        output=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ 2>/dev/null) || error_json "Failed to get volume" "WPCTL_ERROR"
+
+        # Parse: "Volume: 0.75" or "Volume: 0.75 [MUTED]"
+        volume=$(echo "$output" | grep -oP 'Volume: \K[\d.]+' | awk '{print int($1*100)}')
+        muted="false"
+        [[ "$output" == *"[MUTED]"* ]] && muted="true"
+
+        echo "{\"volume\": $volume, \"muted\": $muted}"
+        ;;
+
+    set)
+        # Set volume (0-100)
+        if [[ ! "$VALUE" =~ ^[0-9]+$ ]] || [[ "$VALUE" -lt 0 ]] || [[ "$VALUE" -gt 100 ]]; then
+            error_json "Invalid volume value: $VALUE (must be 0-100)" "INVALID_VALUE"
+        fi
+
+        # Convert to decimal (wpctl uses 0.0-1.0)
+        decimal=$(awk "BEGIN {printf \"%.2f\", $VALUE/100}")
+        wpctl set-volume @DEFAULT_AUDIO_SINK@ "$decimal" 2>/dev/null || error_json "Failed to set volume" "WPCTL_ERROR"
+        ;;
+
+    up)
+        # Increase volume by STEP (default 5)
+        step="${VALUE:-5}"
+        wpctl set-volume --limit 1.0 @DEFAULT_AUDIO_SINK@ "${step}%+" 2>/dev/null || error_json "Failed to increase volume" "WPCTL_ERROR"
+        ;;
+
+    down)
+        # Decrease volume by STEP (default 5)
+        step="${VALUE:-5}"
+        wpctl set-volume @DEFAULT_AUDIO_SINK@ "${step}%-" 2>/dev/null || error_json "Failed to decrease volume" "WPCTL_ERROR"
+        ;;
+
+    mute)
+        # Toggle mute
+        wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle 2>/dev/null || error_json "Failed to toggle mute" "WPCTL_ERROR"
+        ;;
+
+    device)
+        # Switch output device
+        device_id="$VALUE"
+        if [[ ! "$device_id" =~ ^[0-9]+$ ]]; then
+            error_json "Invalid device ID: $device_id" "INVALID_VALUE"
+        fi
+        wpctl set-default "$device_id" 2>/dev/null || error_json "Failed to set default device" "WPCTL_ERROR"
+        ;;
+
+    *)
+        error_json "Unknown action: $ACTION" "INVALID_ACTION"
+        ;;
+esac

--- a/home-modules/desktop/eww-device-controls/widgets/indicators/battery.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/indicators/battery.yuck.nix
@@ -1,0 +1,37 @@
+# Battery Indicator Widget (Laptop Only)
+# Feature 116: Top bar battery status with expandable panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Battery Indicator (Top Bar, Laptop Only)
+; =============================================================================
+
+(defwidget battery-indicator []
+  (eventbox
+    :onclick {battery_expanded ? "" : "eww update battery_expanded=true"}
+    :class "device-indicator battery-indicator"
+    :tooltip "Battery: ''${battery_state.percentage}%''${battery_state.time_remaining != "null" && battery_state.time_remaining != null ? " (" + battery_state.time_remaining + ")" : ""}"
+    (box :class "indicator-box"
+      (label :class "indicator-icon battery-icon ''${battery_state.level}''${battery_state.state == "charging" ? " charging" : ""}"
+             :text {battery_state.icon})
+      (label :class "battery-percent" :text "''${battery_state.percentage}%")
+      (revealer :reveal {battery_expanded}
+                :transition "slideright"
+                :duration "150ms"
+        (box :class "expanded-panel battery-panel" :orientation "v" :spacing 4
+          ; Battery status
+          (box :class "panel-row status-row" :spacing 8
+            (label :class "status-label" :text {battery_state.state == "charging" ? "󰂄 Charging" : battery_state.state == "discharging" ? "󰁹 On Battery" : "󰁹 Full"})
+            (label :class "status-value" :text "''${battery_state.percentage}%"))
+          ; Time remaining
+          (revealer :reveal {battery_state.time_remaining != "null" && battery_state.time_remaining != null}
+                    :transition "slidedown"
+            (box :class "panel-row" :spacing 8
+              (label :class "panel-label" :text "Time")
+              (label :class "panel-value" :text {battery_state.time_remaining ?: ""})))
+          ; Close button
+          (button :class "panel-button close-btn"
+                  :onclick "eww update battery_expanded=false"
+            (label :text "󰅖")))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/indicators/bluetooth.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/indicators/bluetooth.yuck.nix
@@ -1,0 +1,45 @@
+# Bluetooth Indicator Widget
+# Feature 116: Top bar bluetooth control with expandable panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Bluetooth Indicator (Top Bar)
+; =============================================================================
+
+(defwidget bluetooth-indicator []
+  (eventbox
+    :onclick {bluetooth_expanded ? "" : "eww update bluetooth_expanded=true"}
+    :class "device-indicator"
+    :tooltip "Bluetooth: ''${bluetooth_state.enabled ? "On" : "Off"}"
+    (box :class "indicator-box"
+      (label :class "indicator-icon''${bluetooth_state.enabled ? " connected" : " disabled"}"
+             :text {bluetooth_state.enabled ? "󰂯" : "󰂲"})
+      (revealer :reveal {bluetooth_expanded}
+                :transition "slideright"
+                :duration "150ms"
+        (box :class "expanded-panel bluetooth-panel" :orientation "v" :spacing 4
+          ; Toggle switch
+          (box :class "panel-row" :spacing 8
+            (label :class "panel-label" :text "Bluetooth")
+            (button :class "toggle-switch''${bluetooth_state.enabled ? " active" : ""}"
+                    :onclick "${scriptsDir}/bluetooth-control.sh power toggle"
+              (box :class "toggle-track"
+                (box :class "toggle-thumb"))))
+          ; Device list (if enabled)
+          (revealer :reveal {bluetooth_state.enabled && arraylength(bluetooth_state.devices) > 0}
+                    :transition "slidedown"
+            (box :class "device-list" :orientation "v" :spacing 2
+              (for device in {bluetooth_state.devices}
+                (button :class "device-item''${device.connected ? " connected" : ""}"
+                        :onclick "${scriptsDir}/bluetooth-control.sh ''${device.connected ? "disconnect" : "connect"} ''${device.mac}"
+                  (box :spacing 8
+                    (label :class "device-icon" :text {device.icon})
+                    (label :class "device-name" :text {device.name})
+                    (label :class "device-status"
+                           :text {device.connected ? "Connected" : ""}))))))
+          ; Close button
+          (button :class "panel-button close-btn"
+                  :onclick "eww update bluetooth_expanded=false"
+            (label :text "󰅖")))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/indicators/brightness.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/indicators/brightness.yuck.nix
@@ -1,0 +1,42 @@
+# Brightness Indicator Widget (Laptop Only)
+# Feature 116: Top bar brightness control with expandable panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Brightness Indicator (Top Bar, Laptop Only)
+; =============================================================================
+
+(defwidget brightness-indicator []
+  (eventbox
+    :onclick {brightness_expanded ? "" : "eww update brightness_expanded=true"}
+    :onscroll "${scriptsDir}/brightness-control.sh {}"
+    :class "device-indicator"
+    :tooltip "Brightness: ''${brightness_state.display}%"
+    (box :class "indicator-box"
+      (label :class "indicator-icon" :text "󰃟")
+      (revealer :reveal {brightness_expanded}
+                :transition "slideright"
+                :duration "150ms"
+        (box :class "expanded-panel brightness-panel" :orientation "v" :spacing 8
+          ; Display brightness
+          (box :class "slider-row" :spacing 8
+            (label :class "slider-label" :text "󰛨")
+            (scale :class "device-slider brightness-slider"
+                   :value {brightness_state.display}
+                   :min 5 :max 100
+                   :onchange "${scriptsDir}/brightness-control.sh set {}"))
+          ; Keyboard backlight (if available)
+          (revealer :reveal {brightness_state.keyboard != "null" && brightness_state.keyboard != null}
+                    :transition "slidedown"
+            (box :class "slider-row" :spacing 8
+              (label :class "slider-label" :text "󰌌")
+              (scale :class "device-slider keyboard-slider"
+                     :value {brightness_state.keyboard ?: 0}
+                     :min 0 :max 100
+                     :onchange "${scriptsDir}/brightness-control.sh set {} --device keyboard")))
+          ; Close button
+          (button :class "panel-button close-btn"
+                  :onclick "eww update brightness_expanded=false"
+            (label :text "󰅖")))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/indicators/volume.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/indicators/volume.yuck.nix
@@ -1,0 +1,37 @@
+# Volume Indicator Widget
+# Feature 116: Top bar volume control with expandable panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Volume Indicator (Top Bar)
+; =============================================================================
+
+(defwidget volume-indicator []
+  (eventbox
+    :onclick {volume_expanded ? "" : "eww update volume_expanded=true"}
+    :onscroll "${scriptsDir}/volume-control.sh {}"
+    :class "device-indicator"
+    :tooltip "Volume: ''${volume_state.volume}%''${volume_state.muted ? " (Muted)" : ""}"
+    (box :class "indicator-box"
+      (label :class "indicator-icon''${volume_state.muted ? " muted" : ""}"
+             :text {volume_state.icon})
+      (revealer :reveal {volume_expanded}
+                :transition "slideright"
+                :duration "150ms"
+        (box :class "expanded-panel volume-panel" :spacing 8
+          ; Volume slider
+          (scale :class "device-slider volume-slider"
+                 :value {volume_state.volume}
+                 :min 0 :max 100
+                 :onchange "${scriptsDir}/volume-control.sh set {}")
+          ; Mute toggle
+          (button :class "panel-button mute-toggle''${volume_state.muted ? " active" : ""}"
+                  :onclick "${scriptsDir}/volume-control.sh mute"
+                  :tooltip "Toggle Mute"
+            (label :text {volume_state.muted ? "󰝟" : "󰕾"}))
+          ; Close button
+          (button :class "panel-button close-btn"
+                  :onclick "eww update volume_expanded=false"
+            (label :text "󰅖")))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/audio.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/audio.yuck.nix
@@ -1,0 +1,40 @@
+# Audio Section Widget (Devices Tab)
+# Feature 116: Comprehensive audio controls for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Audio Section (Devices Tab)
+; =============================================================================
+
+(defwidget devices-audio-section []
+  (box :class "devices-section audio-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰕾 Audio")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; Current output device
+      (box :class "device-row" :spacing 8
+        (label :class "device-label" :text "Output")
+        (label :class "device-value" :text {device_state.volume.current_device ?: "Unknown"}))
+      ; Volume slider
+      (box :class "slider-row" :spacing 8
+        (label :class "slider-icon" :text {device_state.volume.icon ?: "󰕾"})
+        (scale :class "device-slider"
+               :value {device_state.volume.volume ?: 50}
+               :min 0 :max 100
+               :onchange "${scriptsDir}/volume-control.sh set {}")
+        (label :class "slider-value" :text "''${device_state.volume.volume ?: 50}%")
+        (button :class "mute-btn''${device_state.volume.muted ?: false ? " muted" : ""}"
+                :onclick "${scriptsDir}/volume-control.sh mute"
+          (label :text {device_state.volume.muted ?: false ? "󰝟" : "󰕾"})))
+      ; Output device selector
+      (revealer :reveal {arraylength(device_state.volume.devices ?: []) > 1}
+                :transition "slidedown"
+        (box :class "device-selector" :orientation "v" :spacing 4
+          (for device in {device_state.volume.devices ?: []}
+            (button :class "device-option''${device.active ? " active" : ""}"
+                    :onclick "${scriptsDir}/volume-control.sh device ''${device.id}"
+              (box :spacing 8
+                (label :class "device-type-icon"
+                       :text {device.type == "speaker" ? "󰓃" : device.type == "headphones" ? "󰋋" : "󰂰"})
+                (label :text {device.name})))))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/bluetooth.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/bluetooth.yuck.nix
@@ -1,0 +1,37 @@
+# Bluetooth Section Widget (Devices Tab)
+# Feature 116: Comprehensive bluetooth controls for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Bluetooth Section (Devices Tab)
+; =============================================================================
+
+(defwidget devices-bluetooth-section []
+  (box :class "devices-section bluetooth-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰂯 Bluetooth")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; Adapter toggle
+      (box :class "toggle-row" :spacing 8
+        (label :class "toggle-label" :text "Bluetooth")
+        (button :class "toggle-switch''${device_state.bluetooth.enabled ?: false ? " active" : ""}"
+                :onclick "${scriptsDir}/bluetooth-control.sh power toggle"
+          (box :class "toggle-track"
+            (box :class "toggle-thumb"))))
+      ; Paired devices list
+      (revealer :reveal {device_state.bluetooth.enabled ?: false}
+                :transition "slidedown"
+        (box :class "device-list" :orientation "v" :spacing 4
+          (for device in {device_state.bluetooth.devices ?: []}
+            (box :class "device-item''${device.connected ? " connected" : ""}" :spacing 8
+              (label :class "device-icon" :text {device.icon})
+              (box :class "device-info" :orientation "v"
+                (label :class "device-name" :text {device.name})
+                (label :class "device-mac" :text {device.mac}))
+              (revealer :reveal {device.battery != "null" && device.battery != null}
+                        :transition "slideleft"
+                (label :class "device-battery" :text "󰁹 ''${device.battery}%"))
+              (button :class "connect-btn"
+                      :onclick "${scriptsDir}/bluetooth-control.sh ''${device.connected ? "disconnect" : "connect"} ''${device.mac}"
+                (label :text {device.connected ? "Disconnect" : "Connect"})))))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/display.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/display.yuck.nix
@@ -1,0 +1,32 @@
+# Display Section Widget (Devices Tab, Laptop Only)
+# Feature 116: Brightness controls for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Display Section (Devices Tab, Laptop Only)
+; =============================================================================
+
+(defwidget devices-display-section []
+  (box :class "devices-section display-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰛨 Display")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; Display brightness
+      (box :class "slider-row" :spacing 8
+        (label :class "slider-label" :text "Screen")
+        (scale :class "device-slider"
+               :value {device_state.brightness.display ?: 50}
+               :min 5 :max 100
+               :onchange "${scriptsDir}/brightness-control.sh set {}")
+        (label :class "slider-value" :text "''${device_state.brightness.display ?: 50}%"))
+      ; Keyboard backlight
+      (revealer :reveal {device_state.brightness.keyboard != "null" && device_state.brightness.keyboard != null}
+                :transition "slidedown"
+        (box :class "slider-row" :spacing 8
+          (label :class "slider-label" :text "Keyboard")
+          (scale :class "device-slider"
+                 :value {device_state.brightness.keyboard ?: 0}
+                 :min 0 :max 100
+                 :onchange "${scriptsDir}/brightness-control.sh set {} --device keyboard")
+          (label :class "slider-value" :text "''${device_state.brightness.keyboard ?: 0}%"))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/network.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/network.yuck.nix
@@ -1,0 +1,33 @@
+# Network Section Widget (Devices Tab)
+# Feature 116: WiFi and Tailscale status for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Network Section (Devices Tab)
+; =============================================================================
+
+(defwidget devices-network-section []
+  (box :class "devices-section network-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰖩 Network")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; WiFi status
+      (revealer :reveal {device_state.network.wifi_enabled ?: false}
+                :transition "slidedown"
+        (box :class "network-row wifi-row" :spacing 8
+          (label :class "network-icon" :text {device_state.network.wifi_icon ?: "󰤭"})
+          (box :class "network-info" :orientation "v"
+            (label :class "network-type" :text "WiFi")
+            (label :class "network-value" :text {device_state.network.wifi_ssid ?: "Not connected"}))
+          (revealer :reveal {device_state.network.wifi_signal != "null" && device_state.network.wifi_signal != null}
+                    :transition "slideleft"
+            (label :class "signal-strength" :text "''${device_state.network.wifi_signal ?: 0}%"))))
+      ; Tailscale status
+      (box :class "network-row tailscale-row" :spacing 8
+        (label :class "network-icon''${device_state.network.tailscale_connected ?: false ? " connected" : " disconnected"}"
+               :text "󰖂")
+        (box :class "network-info" :orientation "v"
+          (label :class "network-type" :text "Tailscale")
+          (label :class "network-value"
+                 :text {device_state.network.tailscale_connected ?: false ? device_state.network.tailscale_ip ?: "Connected" : "Disconnected"}))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/power.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/power.yuck.nix
@@ -1,0 +1,50 @@
+# Power Section Widget (Devices Tab, Laptop Only)
+# Feature 116: Battery and power profile controls for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Power Section (Devices Tab, Laptop Only)
+; =============================================================================
+
+(defwidget devices-power-section []
+  (box :class "devices-section power-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰂄 Power")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; Battery status
+      (box :class "battery-status" :spacing 12
+        (label :class "battery-icon ''${device_state.battery.level ?: "normal"}''${device_state.battery.state == "charging" ? " charging" : ""}"
+               :text {device_state.battery.icon ?: "󰁹"})
+        (box :class "battery-info" :orientation "v"
+          (label :class "battery-percent-large" :text "''${device_state.battery.percentage ?: 100}%")
+          (label :class "battery-state" :text {device_state.battery.state == "charging" ? "Charging" : device_state.battery.state == "discharging" ? "Discharging" : "Full"}))
+        (revealer :reveal {device_state.battery.time_remaining != "null" && device_state.battery.time_remaining != null}
+                  :transition "slideleft"
+          (box :class "time-remaining"
+            (label :text {device_state.battery.time_remaining ?: ""}))))
+      ; Battery health (detailed info)
+      (revealer :reveal {device_state.battery.health != "null" && device_state.battery.health != null}
+                :transition "slidedown"
+        (box :class "battery-details" :spacing 16
+          (box :class "detail-item"
+            (label :class "detail-label" :text "Health")
+            (label :class "detail-value" :text "''${device_state.battery.health ?: 100}%"))
+          (revealer :reveal {device_state.battery.cycles != "null" && device_state.battery.cycles != null}
+                    :transition "slideleft"
+            (box :class "detail-item"
+              (label :class "detail-label" :text "Cycles")
+              (label :class "detail-value" :text "''${device_state.battery.cycles ?: 0}")))
+          (revealer :reveal {device_state.battery.power_draw != "null" && device_state.battery.power_draw != null}
+                    :transition "slideleft"
+            (box :class "detail-item"
+              (label :class "detail-label" :text "Power")
+              (label :class "detail-value" :text "''${device_state.battery.power_draw ?: 0}W")))))
+      ; Power profile selector
+      (revealer :reveal {device_state.power_profile != "null" && device_state.power_profile != null}
+                :transition "slidedown"
+        (box :class "power-profiles" :spacing 8
+          (for profile in {device_state.power_profile.available ?: ["balanced"]}
+            (button :class "profile-btn''${device_state.power_profile.current == profile ? " active" : ""}"
+                    :onclick "${scriptsDir}/power-profile-control.sh set ''${profile}"
+              (label :text {profile == "performance" ? "󱐋 Performance" : profile == "balanced" ? "󰾅 Balanced" : "󰾆 Power Saver"}))))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/sections/thermal.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/sections/thermal.yuck.nix
@@ -1,0 +1,33 @@
+# Thermal Section Widget (Devices Tab)
+# Feature 116: Temperature and fan monitoring for monitoring panel
+{ scriptsDir, ... }:
+
+''
+; =============================================================================
+; Thermal Section (Devices Tab)
+; =============================================================================
+
+(defwidget devices-thermal-section []
+  (box :class "devices-section thermal-section" :orientation "v" :spacing 8
+    (label :class "section-title" :text "󰔐 Thermal")
+    (box :class "section-content" :orientation "v" :spacing 8
+      ; CPU temperature
+      (box :class "thermal-row" :spacing 8
+        (label :class "thermal-icon ''${device_state.thermal.level ?: "cool"}"
+               :text {device_state.thermal.icon ?: "󰔐"})
+        (box :class "thermal-info" :orientation "v"
+          (label :class "thermal-label" :text "CPU")
+          (label :class "thermal-value ''${device_state.thermal.level ?: "cool"}"
+                 :text "''${device_state.thermal.cpu_temp ?: 0}C"))
+        (progress :class "thermal-bar ''${device_state.thermal.level ?: "cool"}"
+                  :value {device_state.thermal.cpu_temp ?: 0}
+                  :min 0
+                  :max {device_state.thermal.cpu_temp_max ?: 100}))
+      ; Fan speed (if available)
+      (revealer :reveal {device_state.thermal.fan_speed != "null" && device_state.thermal.fan_speed != null}
+                :transition "slidedown"
+        (box :class "fan-row" :spacing 8
+          (label :class "fan-icon" :text "󰈐")
+          (label :class "fan-label" :text "Fan")
+          (label :class "fan-value" :text "''${device_state.thermal.fan_speed ?: 0} RPM"))))))
+''

--- a/home-modules/desktop/eww-device-controls/widgets/variables.yuck.nix
+++ b/home-modules/desktop/eww-device-controls/widgets/variables.yuck.nix
@@ -1,0 +1,52 @@
+# Eww Variables and Polling Definitions
+# Feature 116: Device control state management
+{ cfg, scriptsDir, isLaptop, ... }:
+
+''
+; =============================================================================
+; Variables and State Definitions
+; =============================================================================
+
+; Hardware capabilities - detected at runtime by device-backend.py
+(defvar hardware_caps '{"has_battery": false, "has_brightness": false, "has_bluetooth": true, "has_wifi": true, "has_thermal_sensors": true}')
+
+; Panel expansion state (for top bar indicators)
+(defvar volume_expanded false)
+(defvar brightness_expanded false)
+(defvar bluetooth_expanded false)
+(defvar battery_expanded false)
+
+; Devices tab visibility flag (controls full state polling)
+(defvar devices_tab_visible false)
+
+; Keyboard navigation state (for focus mode)
+(defvar devices_selected_section 0)
+(defvar devices_selected_item 0)
+
+; =============================================================================
+; Polling Definitions
+; =============================================================================
+
+; Volume state (1s interval for responsive control)
+(defpoll volume_state :interval "${cfg.volumeInterval}"
+  `${scriptsDir}/device-backend.py --mode volume 2>/dev/null || echo '{"volume": 50, "muted": false, "icon": "󰕾", "current_device": "Unknown", "devices": []}'`)
+
+; Bluetooth state (3s interval)
+(defpoll bluetooth_state :interval "${cfg.bluetoothInterval}"
+  `${scriptsDir}/device-backend.py --mode bluetooth 2>/dev/null || echo '{"enabled": false, "scanning": false, "devices": []}'`)
+
+${if isLaptop then ''
+; Brightness state (2s interval, laptop only)
+(defpoll brightness_state :interval "${cfg.brightnessInterval}"
+  `${scriptsDir}/device-backend.py --mode brightness 2>/dev/null || echo '{"display": 50, "display_device": "", "keyboard": null, "keyboard_device": null}'`)
+
+; Battery state (5s interval, laptop only)
+(defpoll battery_state :interval "${cfg.batteryInterval}"
+  `${scriptsDir}/device-backend.py --mode battery 2>/dev/null || echo '{"percentage": 100, "state": "full", "time_remaining": null, "icon": "󰁹", "level": "full"}'`)
+'' else ""}
+
+; Full device state for Devices tab (only poll when tab visible)
+(defpoll device_state :interval "${cfg.fullStateInterval}"
+  :run-while {devices_tab_visible}
+  `${scriptsDir}/device-backend.py 2>/dev/null || echo '{}'`)
+''

--- a/home-modules/desktop/eww-quick-panel.nix
+++ b/home-modules/desktop/eww-quick-panel.nix
@@ -1,3 +1,15 @@
+# DEPRECATED: Feature 116 - This module is superseded by eww-device-controls
+# Device controls (brightness, volume, bluetooth) are now handled by the unified
+# eww-device-controls module. This module is kept for backwards compatibility
+# but is disabled by default.
+#
+# Migration: Enable programs.eww-device-controls instead of this module.
+# The new device controls provide:
+# - Hardware-adaptive controls (only shows available hardware)
+# - Expandable top bar panels
+# - Comprehensive Devices tab in monitoring panel
+#
+# See: specs/116-use-eww-device/quickstart.md
 { config, lib, pkgs, osConfig ? null, ... }:
 
 let
@@ -214,7 +226,20 @@ grim -g "$(slurp)" - | wl-copy
 '';
 
 in {
-  options.programs.eww-quick-panel.enable = lib.mkEnableOption "Quick settings Eww panel";
+  options.programs.eww-quick-panel.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;  # DEPRECATED: Feature 116 - Disabled by default, use eww-device-controls instead
+    description = ''
+      DEPRECATED: Enable Quick settings Eww panel.
+
+      This module is superseded by programs.eww-device-controls which provides:
+      - Hardware-adaptive controls (only shows available hardware)
+      - Expandable top bar panels for volume, brightness, bluetooth, battery
+      - Comprehensive Devices tab in monitoring panel (Alt+7)
+
+      Migration: Set programs.eww-device-controls.enable = true instead.
+    '';
+  };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.eww toggleScript screenshotScript ];

--- a/home-modules/thinkpad.nix
+++ b/home-modules/thinkpad.nix
@@ -17,6 +17,7 @@
     ./desktop/eww-quick-panel.nix
     ./desktop/eww-top-bar.nix
     ./desktop/eww-monitoring-panel.nix
+    ./desktop/eww-device-controls.nix  # Feature 116: Unified device controls
     ./desktop/swaync.nix
     ./desktop/sway-config-manager.nix
 
@@ -68,6 +69,9 @@
 
   # eww monitoring panel
   programs.eww-monitoring-panel.enable = true;
+
+  # eww device controls (Feature 116)
+  programs.eww-device-controls.enable = true;
 
   # sway-easyfocus - Keyboard-driven window hints
   programs.sway-easyfocus = {

--- a/home-vpittamp.nix
+++ b/home-vpittamp.nix
@@ -12,6 +12,7 @@
     ./home-modules/desktop/eww-workspace-bar.nix  # SVG workspace bar with icons
     ./home-modules/desktop/eww-top-bar.nix  # Feature 060: Eww top bar with system metrics
     ./home-modules/desktop/eww-monitoring-panel.nix  # Feature 085: Live monitoring panel
+    ./home-modules/desktop/eww-device-controls.nix  # Feature 116: Unified device controls
     ./home-modules/desktop/sway-config-manager.nix  # Feature 047: Dynamic configuration management
     ./home-modules/profiles/declarative-cleanup.nix  # Automatic XDG cleanup
 
@@ -86,6 +87,10 @@
   programs.eww-monitoring-panel = {
     enable = true;  # Toggle with Mod+m, F10 for focus mode
   };
+
+  # Feature 116: Unified device controls
+  # Hardware-adaptive device controls for bare metal NixOS machines
+  programs.eww-device-controls.enable = true;
 
   # Monitor configuration for M1, Hetzner, and Ryzen
   # Passed to eww-monitoring-panel for correct display output

--- a/specs/116-use-eww-device/checklists/requirements.md
+++ b/specs/116-use-eww-device/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Unified Eww Device Control Panel
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Hardware-adaptive design based on ThinkPad (laptop) vs Ryzen (desktop) differences
+- Consolidates existing quick panel into unified system
+- Adds Devices tab as 7th tab in monitoring panel (index 6)

--- a/specs/116-use-eww-device/contracts/device-backend.md
+++ b/specs/116-use-eww-device/contracts/device-backend.md
@@ -1,0 +1,279 @@
+# Contract: Device Backend Scripts
+
+**Feature**: 116-use-eww-device
+**Date**: 2025-12-13
+
+## Overview
+
+This document defines the interface contracts for backend scripts that provide device state and control operations to Eww widgets.
+
+---
+
+## 1. device-backend.py
+
+Main unified backend script for device state queries.
+
+### Interface
+
+```
+Usage: device-backend.py [--mode MODE] [--listen]
+
+Options:
+  --mode MODE    Query mode: full | volume | brightness | bluetooth | battery | thermal | network
+                 Default: full (all devices)
+  --listen       Stream updates continuously (for deflisten)
+
+Output: JSON to stdout
+```
+
+### Modes
+
+| Mode       | Output | Use Case |
+|------------|--------|----------|
+| full       | Complete DeviceState | Initial load, monitoring panel |
+| volume     | VolumeState only | Top bar volume widget |
+| brightness | BrightnessState only | Top bar brightness widget |
+| bluetooth  | BluetoothState only | Top bar bluetooth widget |
+| battery    | BatteryState only | Top bar battery widget |
+| thermal    | ThermalState only | Monitoring panel |
+| network    | NetworkState only | Top bar network widget |
+
+### Examples
+
+```bash
+# Full state query
+./device-backend.py
+# Returns: {"volume": {...}, "brightness": {...}, ...}
+
+# Volume only
+./device-backend.py --mode volume
+# Returns: {"volume": 75, "muted": false, "icon": "󰕾", ...}
+
+# Streaming mode for deflisten
+./device-backend.py --mode volume --listen
+# Outputs JSON on each volume change
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Success |
+| 1    | Invalid arguments |
+| 2    | Hardware detection failed |
+| 3    | Permission denied |
+
+---
+
+## 2. volume-control.sh
+
+Volume adjustment wrapper for onclick handlers.
+
+### Interface
+
+```
+Usage: volume-control.sh ACTION [VALUE]
+
+Actions:
+  get           Get current volume (JSON)
+  set VALUE     Set volume to VALUE (0-100)
+  up [STEP]     Increase volume by STEP (default: 5)
+  down [STEP]   Decrease volume by STEP (default: 5)
+  mute          Toggle mute
+  device ID     Switch to device ID
+
+Output: JSON status or empty
+Exit: 0 on success, 1 on error
+```
+
+### Examples
+
+```bash
+# Get current volume
+./volume-control.sh get
+# Returns: {"volume": 75, "muted": false}
+
+# Set volume to 50%
+./volume-control.sh set 50
+
+# Increase by 5%
+./volume-control.sh up
+
+# Toggle mute
+./volume-control.sh mute
+
+# Switch output device
+./volume-control.sh device 52
+```
+
+---
+
+## 3. brightness-control.sh
+
+Brightness adjustment wrapper.
+
+### Interface
+
+```
+Usage: brightness-control.sh ACTION [VALUE] [--device DEVICE]
+
+Actions:
+  get           Get current brightness (JSON)
+  set VALUE     Set brightness to VALUE (0-100)
+  up [STEP]     Increase by STEP (default: 5)
+  down [STEP]   Decrease by STEP (default: 5)
+
+Options:
+  --device DEVICE  Target device (display|keyboard)
+                   Default: display
+
+Output: JSON status or empty
+Exit: 0 on success, 1 on error, 2 if device unavailable
+```
+
+### Examples
+
+```bash
+# Get display brightness
+./brightness-control.sh get
+
+# Set display to 75%
+./brightness-control.sh set 75
+
+# Decrease keyboard backlight
+./brightness-control.sh down --device keyboard
+```
+
+---
+
+## 4. bluetooth-control.sh
+
+Bluetooth control wrapper.
+
+### Interface
+
+```
+Usage: bluetooth-control.sh ACTION [TARGET]
+
+Actions:
+  get           Get bluetooth state (JSON)
+  power [on|off|toggle]  Control adapter power
+  connect MAC   Connect to device
+  disconnect MAC  Disconnect device
+  scan [on|off] Control scanning
+
+Output: JSON status or empty
+Exit: 0 on success, 1 on error, 2 if bluetooth unavailable
+```
+
+### Examples
+
+```bash
+# Get bluetooth state
+./bluetooth-control.sh get
+
+# Toggle power
+./bluetooth-control.sh power toggle
+
+# Connect to device
+./bluetooth-control.sh connect E1:4B:6C:22:56:F0
+
+# Start scanning
+./bluetooth-control.sh scan on
+```
+
+---
+
+## 5. power-profile-control.sh
+
+Power profile control wrapper.
+
+### Interface
+
+```
+Usage: power-profile-control.sh ACTION [PROFILE]
+
+Actions:
+  get           Get current profile (JSON)
+  set PROFILE   Set profile (performance|balanced|power-saver)
+  cycle         Cycle to next profile
+
+Output: JSON status or empty
+Exit: 0 on success, 1 on error, 2 if profiles unavailable
+```
+
+### Examples
+
+```bash
+# Get current profile
+./power-profile-control.sh get
+# Returns: {"current": "balanced", "on_ac": true}
+
+# Set to performance
+./power-profile-control.sh set performance
+
+# Cycle profiles
+./power-profile-control.sh cycle
+```
+
+---
+
+## Eww Integration Patterns
+
+### defpoll (Polling)
+
+```yuck
+(defpoll device_state :interval "2s"
+  :run-while {current_view_index == 6}
+  `device-backend.py`)
+
+(defpoll volume_state :interval "1s"
+  `device-backend.py --mode volume`)
+```
+
+### deflisten (Event-Driven)
+
+```yuck
+(deflisten volume_stream
+  `device-backend.py --mode volume --listen`)
+```
+
+### onclick Handlers
+
+```yuck
+(button
+  :onclick "volume-control.sh mute"
+  :onscroll "echo {} | sed -e 's/up/up/g' -e 's/down/down/g' | xargs volume-control.sh"
+  ...)
+```
+
+---
+
+## Error Handling
+
+All scripts follow consistent error patterns:
+
+1. **stderr**: Human-readable error messages
+2. **stdout**: Empty or error JSON on failure
+3. **Exit code**: Non-zero on error
+
+### Error JSON Format
+
+```json
+{
+  "error": true,
+  "message": "Bluetooth adapter not found",
+  "code": "BT_UNAVAILABLE"
+}
+```
+
+### Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `BT_UNAVAILABLE` | Bluetooth adapter not found |
+| `BRIGHTNESS_UNAVAILABLE` | No brightness device |
+| `BATTERY_UNAVAILABLE` | No battery present |
+| `PERMISSION_DENIED` | Insufficient permissions |
+| `INVALID_VALUE` | Value out of range |
+| `DEVICE_NOT_FOUND` | Specified device not found |

--- a/specs/116-use-eww-device/data-model.md
+++ b/specs/116-use-eww-device/data-model.md
@@ -1,0 +1,421 @@
+# Data Model: Eww Device Controls
+
+**Feature**: 116-use-eww-device
+**Date**: 2025-12-13
+
+## Overview
+
+This document defines the data structures used by the device control backend and Eww widgets. All data is stateless (queried in real-time from system).
+
+---
+
+## Core Entities
+
+### DeviceState
+
+Root entity representing the complete state of all device controls.
+
+```python
+@dataclass
+class DeviceState:
+    """Complete device state for Eww widget consumption."""
+
+    # Audio
+    volume: VolumeState
+
+    # Display (laptop only)
+    brightness: BrightnessState | None
+
+    # Bluetooth
+    bluetooth: BluetoothState
+
+    # Power (laptop only)
+    battery: BatteryState | None
+    power_profile: PowerProfileState | None
+
+    # Thermal
+    thermal: ThermalState
+
+    # Network
+    network: NetworkState
+
+    # Hardware detection flags
+    hardware: HardwareCapabilities
+```
+
+---
+
+### VolumeState
+
+Audio volume and output device information.
+
+```python
+@dataclass
+class VolumeState:
+    """Audio volume state."""
+
+    volume: int              # 0-100 percentage
+    muted: bool              # True if muted
+    icon: str                # Nerd font icon based on level
+
+    # Output device
+    current_device: str      # Active output device name
+    devices: list[AudioDevice]  # Available output devices
+
+@dataclass
+class AudioDevice:
+    """Audio output device."""
+
+    id: int                  # WirePlumber device ID
+    name: str                # Display name
+    type: str                # "speaker" | "headphones" | "bluetooth"
+    active: bool             # Currently selected
+```
+
+**Icon Mapping**:
+| Volume Level | Muted | Icon |
+|-------------|-------|------|
+| 0           | -     | 󰝟    |
+| 1-33        | No    | 󰕿    |
+| 34-66       | No    | 󰖀    |
+| 67-100      | No    | 󰕾    |
+| Any         | Yes   | 󰝟    |
+
+---
+
+### BrightnessState
+
+Display and keyboard backlight brightness (laptop only).
+
+```python
+@dataclass
+class BrightnessState:
+    """Brightness state for displays and keyboard."""
+
+    # Display brightness
+    display: int             # 0-100 percentage
+    display_device: str      # e.g., "intel_backlight"
+
+    # Keyboard backlight (optional)
+    keyboard: int | None     # 0-100 percentage or None if unavailable
+    keyboard_device: str | None  # e.g., "tpacpi::kbd_backlight"
+```
+
+**Device Detection**:
+- ThinkPad display: `intel_backlight`
+- ThinkPad keyboard: `tpacpi::kbd_backlight`
+- M1 display: `apple-panel-bl`
+- M1 keyboard: `kbd_backlight`
+
+---
+
+### BluetoothState
+
+Bluetooth adapter and paired device information.
+
+```python
+@dataclass
+class BluetoothState:
+    """Bluetooth adapter and device state."""
+
+    enabled: bool            # Adapter power state
+    scanning: bool           # Currently scanning
+    devices: list[BluetoothDevice]  # Paired devices
+
+@dataclass
+class BluetoothDevice:
+    """Paired Bluetooth device."""
+
+    mac: str                 # MAC address
+    name: str                # Device name
+    type: str                # "headphones" | "keyboard" | "mouse" | "speaker" | "other"
+    connected: bool          # Currently connected
+    battery: int | None      # Battery level if available
+    icon: str                # Nerd font icon based on type
+```
+
+**Icon Mapping**:
+| Type       | Icon |
+|------------|------|
+| headphones | 󰋋    |
+| keyboard   | 󰌌    |
+| mouse      | 󰍽    |
+| speaker    | 󰓃    |
+| other      | 󰂯    |
+
+---
+
+### BatteryState
+
+Battery status (laptop only).
+
+```python
+@dataclass
+class BatteryState:
+    """Battery status."""
+
+    percentage: int          # 0-100
+    state: str               # "charging" | "discharging" | "full" | "empty"
+    time_remaining: str | None  # e.g., "2h 30m" or None
+    icon: str                # Nerd font icon based on level/state
+    level: str               # "critical" | "low" | "normal" | "full"
+
+    # Health info (for monitoring panel)
+    health: int | None       # Battery health percentage
+    cycles: int | None       # Charge cycles
+    power_draw: float | None # Current power draw in watts
+```
+
+**Icon Mapping**:
+| State      | Level    | Icon |
+|------------|----------|------|
+| charging   | any      | 󰂄    |
+| discharging| 0-10     | 󰂎    |
+| discharging| 11-20    | 󰁺    |
+| discharging| 21-30    | 󰁻    |
+| discharging| 31-40    | 󰁼    |
+| discharging| 41-50    | 󰁽    |
+| discharging| 51-60    | 󰁾    |
+| discharging| 61-70    | 󰁿    |
+| discharging| 71-80    | 󰂀    |
+| discharging| 81-90    | 󰂁    |
+| discharging| 91-100   | 󰂂    |
+| full       | 100      | 󰁹    |
+
+---
+
+### PowerProfileState
+
+Power profile / TLP status (laptop only).
+
+```python
+@dataclass
+class PowerProfileState:
+    """Power profile status."""
+
+    current: str             # "performance" | "balanced" | "power-saver"
+    on_ac: bool              # True if plugged in
+    available: list[str]     # Available profiles
+    icon: str                # Nerd font icon
+```
+
+**Icon Mapping**:
+| Profile     | Icon |
+|-------------|------|
+| performance | 󱐋    |
+| balanced    | 󰾅    |
+| power-saver | 󰾆    |
+
+---
+
+### ThermalState
+
+CPU temperature and fan status.
+
+```python
+@dataclass
+class ThermalState:
+    """Thermal monitoring state."""
+
+    cpu_temp: int            # CPU temperature in Celsius
+    cpu_temp_max: int        # Max safe temperature
+    level: str               # "cool" | "warm" | "hot" | "critical"
+    icon: str                # Nerd font icon
+
+    # Fan info (optional)
+    fan_speed: int | None    # RPM if available
+    fan_speed_max: int | None
+
+@dataclass
+class ThermalZone:
+    """Individual thermal zone (for monitoring panel)."""
+
+    name: str                # e.g., "CPU", "GPU", "SSD"
+    temp: int                # Temperature in Celsius
+    max_temp: int            # Threshold temperature
+```
+
+**Level Thresholds**:
+| Temperature | Level    |
+|------------|----------|
+| < 50°C     | cool     |
+| 50-70°C    | warm     |
+| 70-85°C    | hot      |
+| > 85°C     | critical |
+
+---
+
+### NetworkState
+
+WiFi and VPN connection status.
+
+```python
+@dataclass
+class NetworkState:
+    """Network connection state."""
+
+    # WiFi
+    wifi_enabled: bool       # WiFi radio state
+    wifi_connected: bool     # Connected to a network
+    wifi_ssid: str | None    # Current SSID
+    wifi_signal: int | None  # Signal strength 0-100
+    wifi_icon: str           # Icon based on signal
+
+    # VPN
+    tailscale_connected: bool
+    tailscale_ip: str | None
+```
+
+**WiFi Icon Mapping**:
+| Signal    | Icon |
+|-----------|------|
+| 0         | 󰤯    |
+| 1-25      | 󰤟    |
+| 26-50     | 󰤢    |
+| 51-75     | 󰤥    |
+| 76-100    | 󰤨    |
+| Disabled  | 󰤭    |
+
+---
+
+### HardwareCapabilities
+
+Detected hardware features per machine.
+
+```python
+@dataclass
+class HardwareCapabilities:
+    """Hardware detection flags."""
+
+    has_battery: bool        # Battery present
+    has_brightness: bool     # Display brightness controllable
+    has_keyboard_backlight: bool  # Keyboard backlight present
+    has_bluetooth: bool      # Bluetooth adapter present
+    has_wifi: bool           # WiFi adapter present
+    has_thermal_sensors: bool # lm_sensors available
+    has_fan_control: bool    # Fan speed readable
+    has_power_profiles: bool # TLP or power-profiles-daemon
+
+    # Machine identification
+    hostname: str            # "thinkpad" | "ryzen" | etc.
+    is_laptop: bool          # Derived from has_battery
+```
+
+**Detection Paths**:
+| Capability       | Detection Path |
+|-----------------|----------------|
+| battery         | `/sys/class/power_supply/BAT*` |
+| brightness      | `/sys/class/backlight/*` |
+| keyboard_backlight | `/sys/class/leds/*kbd*` |
+| bluetooth       | `/sys/class/bluetooth/*` |
+| wifi            | `/sys/class/net/wl*` |
+| thermal_sensors | `/sys/class/hwmon/*` |
+
+---
+
+## JSON Output Format
+
+The backend script outputs a single JSON object for Eww consumption.
+
+```json
+{
+  "volume": {
+    "volume": 75,
+    "muted": false,
+    "icon": "󰕾",
+    "current_device": "Built-in Speakers",
+    "devices": [
+      {"id": 41, "name": "Built-in Speakers", "type": "speaker", "active": true},
+      {"id": 52, "name": "Bluetooth Headphones", "type": "bluetooth", "active": false}
+    ]
+  },
+  "brightness": {
+    "display": 80,
+    "display_device": "intel_backlight",
+    "keyboard": 50,
+    "keyboard_device": "tpacpi::kbd_backlight"
+  },
+  "bluetooth": {
+    "enabled": true,
+    "scanning": false,
+    "devices": [
+      {"mac": "E1:4B:6C:22:56:F0", "name": "AirPods Pro", "type": "headphones", "connected": true, "battery": 85, "icon": "󰋋"}
+    ]
+  },
+  "battery": {
+    "percentage": 72,
+    "state": "discharging",
+    "time_remaining": "3h 45m",
+    "icon": "󰁿",
+    "level": "normal",
+    "health": 92,
+    "cycles": 245,
+    "power_draw": 8.5
+  },
+  "power_profile": {
+    "current": "balanced",
+    "on_ac": false,
+    "available": ["performance", "balanced", "power-saver"],
+    "icon": "󰾅"
+  },
+  "thermal": {
+    "cpu_temp": 58,
+    "cpu_temp_max": 100,
+    "level": "warm",
+    "icon": "󰔐",
+    "fan_speed": 2500,
+    "fan_speed_max": 5000
+  },
+  "network": {
+    "wifi_enabled": true,
+    "wifi_connected": true,
+    "wifi_ssid": "HomeNetwork",
+    "wifi_signal": 85,
+    "wifi_icon": "󰤨",
+    "tailscale_connected": true,
+    "tailscale_ip": "100.64.0.5"
+  },
+  "hardware": {
+    "has_battery": true,
+    "has_brightness": true,
+    "has_keyboard_backlight": true,
+    "has_bluetooth": true,
+    "has_wifi": true,
+    "has_thermal_sensors": true,
+    "has_fan_control": true,
+    "has_power_profiles": true,
+    "hostname": "thinkpad",
+    "is_laptop": true
+  }
+}
+```
+
+---
+
+## State Transitions
+
+### Volume
+- `set_volume(value: int)` → Updates volume 0-100
+- `toggle_mute()` → Toggles muted state
+- `set_device(device_id: int)` → Switches output device
+
+### Brightness
+- `set_brightness(value: int, device: str)` → Updates brightness 0-100
+
+### Bluetooth
+- `toggle_power()` → Toggles adapter power
+- `connect(mac: str)` → Connects to device
+- `disconnect(mac: str)` → Disconnects device
+
+### Power Profile
+- `set_profile(profile: str)` → Switches power profile
+
+---
+
+## Validation Rules
+
+1. **Volume**: Must be 0-100, integers only
+2. **Brightness**: Must be 0-100, integers only
+3. **MAC addresses**: Must match `XX:XX:XX:XX:XX:XX` format
+4. **Power profiles**: Must be one of available profiles
+5. **Hardware flags**: Read-only, determined at startup

--- a/specs/116-use-eww-device/plan.md
+++ b/specs/116-use-eww-device/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Unified Eww Device Control Panel
+
+**Branch**: `116-use-eww-device` | **Date**: 2025-12-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/116-use-eww-device/spec.md`
+
+## Summary
+
+Create a unified Eww-based device control system for bare metal NixOS machines (ThinkPad, Ryzen). The feature provides tiered device controls: quick controls via expandable top bar panels (volume, brightness, Bluetooth, battery) and a comprehensive Devices tab in the monitoring panel for detailed hardware status and configuration. Hardware-adaptive detection ensures only applicable controls are shown per machine. Deprecates the existing eww-quick-panel module to consolidate device controls.
+
+## Technical Context
+
+**Language/Version**: Nix (flakes), Python 3.11+ (backend scripts), Yuck/SCSS (Eww widgets)
+**Primary Dependencies**: Eww 0.4+ (GTK3 widgets), PipeWire/WirePlumber (audio), BlueZ (Bluetooth), UPower (battery), brightnessctl (brightness), TLP (power profiles), lm_sensors (thermals)
+**Storage**: N/A (stateless - queries system state in real-time)
+**Testing**: Manual verification on ThinkPad and Ryzen, sway-test framework for widget visibility
+**Target Platform**: NixOS on bare metal (ThinkPad laptop, Ryzen desktop)
+**Project Type**: Single - NixOS home-manager module with Eww widgets
+**Performance Goals**: <100ms latency for device state updates, <2 seconds for user to complete device adjustment
+**Constraints**: <50MB additional memory overhead, hardware-adaptive (no false controls), click-outside-to-close UX
+**Scale/Scope**: 2 target machines (ThinkPad, Ryzen), ~10 device controls total
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Modular Composition | ✅ PASS | New module `eww-device-controls.nix` follows single responsibility, composes with existing eww-top-bar and eww-monitoring-panel |
+| II. Reference Implementation Flexibility | ✅ PASS | ThinkPad as reference for laptop features, Ryzen as reference for desktop-only features |
+| III. Test-Before-Apply | ✅ PASS | Will use `nixos-rebuild dry-build` before applying changes |
+| IV. Override Priority Discipline | ✅ PASS | Use `mkDefault` for device detection flags, normal assignment for widget config |
+| V. Platform Flexibility | ✅ PASS | Hardware detection via conditional logic (battery exists? brightness device present?) |
+| VI. Declarative Configuration | ✅ PASS | All widget config in Nix, no imperative scripts except device query backends |
+| VII. Documentation as Code | ✅ PASS | Will create quickstart.md, update CLAUDE.md with device control keybindings |
+| X. Python Development Standards | ✅ PASS | Backend scripts use Python 3.11+, async patterns for D-Bus monitoring |
+| XII. Forward-Only Development | ✅ PASS | Deprecates eww-quick-panel entirely, no backwards compatibility needed |
+| XIV. Test-Driven Development | ⚠️ PARTIAL | Widget visibility tests via sway-test, device operations require manual verification |
+| XV. Sway Test Framework | ✅ PASS | Will create JSON test cases for Devices tab visibility and keyboard navigation |
+
+**Gate Status**: ✅ PASS - All critical principles satisfied. Partial TDD is acceptable given hardware interaction requirements.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/116-use-eww-device/
+├── plan.md              # This file
+├── research.md          # Phase 0: Tool research and best practices
+├── data-model.md        # Phase 1: Device state models
+├── quickstart.md        # Phase 1: User guide for device controls
+├── contracts/           # Phase 1: Backend script interfaces
+│   └── device-backend.md
+└── tasks.md             # Phase 2: Implementation tasks
+```
+
+### Source Code (repository root)
+
+```text
+home-modules/desktop/
+├── eww-device-controls.nix          # NEW: Main device controls module
+├── eww-device-controls/
+│   ├── eww.yuck.nix                 # Widget definitions (expandable panels, sliders)
+│   ├── eww.scss.nix                 # Catppuccin Mocha styling
+│   └── scripts/
+│       ├── device-backend.py        # Unified device state backend
+│       ├── volume-control.sh        # Volume adjustment wrapper
+│       ├── brightness-control.sh    # Brightness adjustment wrapper
+│       └── bluetooth-control.sh     # Bluetooth toggle/connect wrapper
+├── eww-top-bar/
+│   └── [existing - will integrate device indicators with expandable panels]
+├── eww-monitoring-panel.nix
+│   └── [existing - will add Devices tab at index 6]
+└── eww-quick-panel.nix              # DEPRECATED: Disable by default
+
+tests/116-use-eww-device/
+├── test_devices_tab_visible.json    # Sway-test: Devices tab appears on Alt+7
+├── test_keyboard_navigation.json    # Sway-test: j/k/Enter works in focus mode
+└── test_hardware_detection.json     # Sway-test: Only applicable controls shown
+```
+
+**Structure Decision**: Follows existing Eww module pattern (eww-top-bar, eww-monitoring-panel). Device controls module is standalone but integrates with both existing widgets. Scripts follow the existing Python backend pattern (volume-monitor.py, bluetooth-monitor.py).
+
+## Complexity Tracking
+
+No constitution violations requiring justification. The design follows existing patterns and consolidates rather than adds complexity.

--- a/specs/116-use-eww-device/quickstart.md
+++ b/specs/116-use-eww-device/quickstart.md
@@ -1,0 +1,288 @@
+# Quickstart: Eww Device Controls
+
+**Feature**: 116-use-eww-device
+**Date**: 2025-12-13
+
+## Overview
+
+Unified device control system for bare metal NixOS machines providing quick access via top bar and comprehensive monitoring via the Devices tab.
+
+---
+
+## Quick Access (Top Bar)
+
+### Volume Control
+
+| Action | Method |
+|--------|--------|
+| View volume | Look at 󰕾 icon in top bar |
+| Adjust volume | Click icon, drag slider |
+| Quick adjust | Scroll over icon |
+| Mute toggle | Click 󰝟 icon in expanded panel |
+| Switch output | Click device in dropdown |
+
+### Brightness Control (Laptop Only)
+
+| Action | Method |
+|--------|--------|
+| View brightness | Look at 󰃟 icon in top bar |
+| Adjust display | Click icon, drag slider |
+| Adjust keyboard | Click icon, use second slider |
+
+### Bluetooth
+
+| Action | Method |
+|--------|--------|
+| View status | Look at 󰂯 icon (blue = connected) |
+| Toggle Bluetooth | Click icon, use toggle switch |
+| Connect device | Click device in list |
+| Disconnect device | Click connected device |
+
+### Battery (Laptop Only)
+
+| Action | Method |
+|--------|--------|
+| View percentage | Look at battery icon |
+| View time remaining | Click to expand |
+| View power profile | See profile pill in expanded panel |
+| Change profile | Click profile to cycle |
+
+---
+
+## Comprehensive Dashboard (Monitoring Panel)
+
+### Opening the Devices Tab
+
+| Method | Keys |
+|--------|------|
+| Open panel | `Mod+M` |
+| Switch to Devices | `Alt+7` (or click tab) |
+| Enter focus mode | `Mod+Shift+M` |
+
+### Keyboard Navigation (Focus Mode)
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Navigate down |
+| `k` / `↑` | Navigate up |
+| `Enter` / `l` | Select/toggle item |
+| `h` / `←` | Go back / collapse |
+| `Escape` | Exit focus mode |
+
+### Dashboard Sections
+
+1. **Audio**
+   - Current output device
+   - Volume slider
+   - Microphone status
+   - Output device selector
+
+2. **Display** (Laptop)
+   - Display brightness slider
+   - Keyboard backlight slider (if available)
+
+3. **Bluetooth**
+   - Adapter toggle
+   - Paired devices list
+   - Connection status per device
+   - Device battery levels
+
+4. **Power** (Laptop)
+   - Battery percentage and health
+   - Charging status
+   - Time remaining
+   - Power profile selector
+   - Current power draw
+
+5. **Thermal**
+   - CPU temperature
+   - Fan speed (if available)
+   - Thermal zone readings
+
+6. **Network**
+   - WiFi status and SSID
+   - Signal strength
+   - Tailscale connection status
+
+---
+
+## Hardware Differences
+
+### M1 MacBook Pro (Laptop)
+
+Available controls:
+- ✅ Volume (speaker, headphones)
+- ✅ Display brightness (apple-panel-bl)
+- ✅ Keyboard backlight (kbd_backlight)
+- ✅ Bluetooth
+- ✅ Battery status
+- ✅ Power profiles (powerprofilesctl)
+- ✅ Thermal monitoring
+- ⚠️ Fan control (limited visibility)
+- ✅ WiFi
+- ✅ Tailscale
+
+### ThinkPad (Laptop)
+
+Available controls:
+- ✅ Volume (speaker, headphones)
+- ✅ Display brightness
+- ✅ Keyboard backlight
+- ✅ Bluetooth
+- ✅ Battery status
+- ✅ Power profiles (TLP)
+- ✅ Thermal monitoring
+- ✅ Fan control visibility
+- ✅ WiFi
+- ✅ Tailscale
+
+### Ryzen (Desktop)
+
+Available controls:
+- ✅ Volume (speaker, headphones)
+- ❌ Display brightness (external monitors)
+- ❌ Keyboard backlight
+- ✅ Bluetooth
+- ❌ Battery status
+- ❌ Power profiles
+- ✅ Thermal monitoring
+- ❌ Fan control (external controller)
+- ❌ WiFi (ethernet only)
+- ✅ Tailscale
+
+---
+
+## Troubleshooting
+
+### Volume not responding
+
+```bash
+# Check PipeWire status
+systemctl --user status pipewire
+
+# Restart PipeWire
+systemctl --user restart pipewire
+```
+
+### Brightness not working
+
+```bash
+# Check available devices
+brightnessctl -l
+
+# Verify permissions
+ls -la /sys/class/backlight/*/brightness
+```
+
+### Bluetooth devices not showing
+
+```bash
+# Check Bluetooth service
+systemctl status bluetooth
+
+# Verify adapter power
+bluetoothctl show | grep Powered
+```
+
+### Battery info missing
+
+```bash
+# Check UPower
+upower -e
+upower -i /org/freedesktop/UPower/devices/battery_BAT0
+```
+
+### Panel not updating
+
+```bash
+# Restart the Eww service
+systemctl --user restart eww-top-bar
+
+# Check logs
+journalctl --user -u eww-top-bar -f
+```
+
+---
+
+## CLI Commands
+
+Scripts are installed to `~/.config/eww/eww-device-controls/scripts/`.
+
+### Backend Direct Access
+
+```bash
+# Get full device state (JSON output)
+~/.config/eww/eww-device-controls/scripts/device-backend.py
+
+# Get specific state
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode volume
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode bluetooth
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode brightness
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode battery
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode thermal
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode network
+
+# Stream updates (for deflisten)
+~/.config/eww/eww-device-controls/scripts/device-backend.py --mode volume --listen
+```
+
+### Device Control
+
+```bash
+# Volume (uses wpctl for WirePlumber)
+~/.config/eww/eww-device-controls/scripts/volume-control.sh get
+~/.config/eww/eww-device-controls/scripts/volume-control.sh set 50
+~/.config/eww/eww-device-controls/scripts/volume-control.sh up      # +5%
+~/.config/eww/eww-device-controls/scripts/volume-control.sh down    # -5%
+~/.config/eww/eww-device-controls/scripts/volume-control.sh mute    # toggle
+
+# Brightness (uses brightnessctl)
+~/.config/eww/eww-device-controls/scripts/brightness-control.sh get
+~/.config/eww/eww-device-controls/scripts/brightness-control.sh set 75
+~/.config/eww/eww-device-controls/scripts/brightness-control.sh up --device display
+~/.config/eww/eww-device-controls/scripts/brightness-control.sh down --device keyboard
+
+# Bluetooth (uses bluetoothctl)
+~/.config/eww/eww-device-controls/scripts/bluetooth-control.sh get
+~/.config/eww/eww-device-controls/scripts/bluetooth-control.sh power toggle
+~/.config/eww/eww-device-controls/scripts/bluetooth-control.sh connect E1:4B:6C:22:56:F0
+~/.config/eww/eww-device-controls/scripts/bluetooth-control.sh disconnect E1:4B:6C:22:56:F0
+~/.config/eww/eww-device-controls/scripts/bluetooth-control.sh scan     # 10s scan
+
+# Power profile (uses powerprofilesctl or TLP)
+~/.config/eww/eww-device-controls/scripts/power-profile-control.sh get
+~/.config/eww/eww-device-controls/scripts/power-profile-control.sh set balanced
+~/.config/eww/eww-device-controls/scripts/power-profile-control.sh set performance
+~/.config/eww/eww-device-controls/scripts/power-profile-control.sh set power-saver
+~/.config/eww/eww-device-controls/scripts/power-profile-control.sh cycle   # next profile
+```
+
+---
+
+## Configuration
+
+The device controls are enabled via home-manager:
+
+```nix
+# In home-vpittamp.nix
+programs.eww-device-controls = {
+  enable = true;
+
+  # Optional: override polling intervals
+  volumeInterval = "1s";
+  brightnessInterval = "2s";
+
+  # Optional: disable specific controls
+  showBluetooth = true;
+  showNetwork = true;
+};
+```
+
+---
+
+## Related Features
+
+- **Feature 060**: Eww Top Bar (where device indicators appear)
+- **Feature 085**: Monitoring Panel (where Devices tab lives)
+- **Feature 086**: Panel Focus Mode (keyboard navigation)
+- **Deprecated**: eww-quick-panel (replaced by this feature)

--- a/specs/116-use-eww-device/research.md
+++ b/specs/116-use-eww-device/research.md
@@ -1,0 +1,398 @@
+# Research: Device Control Tools for Eww Integration
+
+**Feature**: 116-use-eww-device
+**Date**: 2025-12-13
+
+## Overview
+
+This document captures research on the CLI tools and best practices for implementing device controls in Eww widgets. The focus is on real-time updates with minimal polling overhead.
+
+---
+
+## 1. Volume Control (WirePlumber/wpctl)
+
+### Decision
+Use `wpctl` for all audio control operations with PipeWire/WirePlumber backend.
+
+### Rationale
+- Native PipeWire tool, no legacy PulseAudio dependencies
+- Simple percentage-based API
+- Supports device enumeration and switching
+
+### Key Commands
+
+```bash
+# Get volume percentage
+wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -oP 'Volume: \K[\d.]+' | awk '{print int($1*100)}'
+
+# Set volume (0-100%)
+wpctl set-volume @DEFAULT_SINK@ 0.75          # 75%
+wpctl set-volume @DEFAULT_SINK@ 5%+           # +5%
+wpctl set-volume @DEFAULT_SINK@ 5%-           # -5%
+wpctl set-volume --limit 1.0 @DEFAULT_SINK@ 10%+  # Cap at 100%
+
+# Mute toggle
+wpctl set-mute @DEFAULT_SINK@ toggle
+
+# List devices
+wpctl status
+
+# Switch output device
+wpctl set-default <device_id>
+```
+
+### Update Strategy
+- **Polling**: 1s interval for defpoll
+- **Event-driven alternative**: Monitor PipeWire D-Bus signals (more complex)
+
+---
+
+## 2. Brightness Control (brightnessctl)
+
+### Decision
+Use `brightnessctl` for both display and keyboard backlight control.
+
+### Rationale
+- Works without X11 (pure sysfs)
+- Supports device enumeration
+- Percentage-based API
+
+### Key Commands
+
+```bash
+# Get brightness percentage
+brightnessctl get | awk -v max=$(brightnessctl max) '{printf "%.0f", ($1/max)*100}'
+# Or simpler:
+brightnessctl -P get                           # Built-in percentage mode
+
+# Set brightness
+brightnessctl set 50%                          # Absolute
+brightnessctl set 5%+                          # Relative increase
+brightnessctl set 5%-                          # Relative decrease
+
+# List devices
+brightnessctl -l
+
+# Control specific device
+brightnessctl -d intel_backlight set 75%       # Display
+brightnessctl -d tpacpi::kbd_backlight set 2   # Keyboard (ThinkPad)
+```
+
+### ThinkPad Device Names
+- Display: `intel_backlight` or `amdgpu_bl0`
+- Keyboard: `tpacpi::kbd_backlight`
+
+### M1 Device Names
+- Display: `apple-panel-bl`
+- Keyboard: `kbd_backlight`
+
+### Update Strategy
+- **Polling**: 2s interval (brightness changes infrequently)
+
+---
+
+## 3. Bluetooth Control (bluetoothctl + D-Bus)
+
+### Decision
+Use `bluetoothctl` for commands, D-Bus for real-time status.
+
+### Rationale
+- `bluetoothctl` is non-interactive for commands
+- D-Bus provides event-driven updates without polling
+
+### Key Commands
+
+```bash
+# Get power state
+bluetoothctl show | grep "Powered:" | awk '{print $2}'
+
+# Toggle power
+bluetoothctl power on
+bluetoothctl power off
+
+# List paired devices
+bluetoothctl devices Paired
+
+# Get device connection status
+bluetoothctl info <MAC> | grep "Connected:" | awk '{print $2}'
+
+# Connect/disconnect
+bluetoothctl connect <MAC>
+bluetoothctl disconnect <MAC>
+```
+
+### D-Bus Monitoring (Event-Driven)
+
+```bash
+# Monitor all Bluetooth events
+gdbus monitor --system --dest org.bluez | grep -E "Connected|Powered"
+```
+
+### Update Strategy
+- **Event-driven**: D-Bus subscription via deflisten script
+- **Fallback polling**: 3s interval
+
+---
+
+## 4. Battery Status (UPower)
+
+### Decision
+Use UPower D-Bus interface for real-time battery monitoring.
+
+### Rationale
+- Event-driven updates on charge/discharge
+- Standard freedesktop interface
+- Rich data (percentage, state, time remaining)
+
+### Key Commands
+
+```bash
+# Get battery percentage
+upower -i $(upower -e | grep BAT) | grep percentage | awk '{print $2}' | tr -d '%'
+
+# Get charging state
+upower -i $(upower -e | grep BAT) | grep state | awk '{print $2}'
+
+# Get time remaining
+upower -i $(upower -e | grep BAT) | grep "time to" | awk '{print $4, $5}'
+```
+
+### D-Bus Monitoring
+
+```bash
+# Monitor battery changes
+gdbus monitor --system --dest org.freedesktop.UPower \
+  --object-path /org/freedesktop/UPower/devices/battery_BAT0
+```
+
+### Update Strategy
+- **Event-driven**: D-Bus subscription
+- Fallback polling: 5s interval
+
+---
+
+## 5. Power Profiles (TLP)
+
+### Decision
+Use TLP CLI for ThinkPad (TLP is already configured), check for power-profiles-daemon as alternative.
+
+### Rationale
+- TLP is already installed on ThinkPad configuration
+- power-profiles-daemon may be available on other systems
+- Note: TLP and power-profiles-daemon conflict; only one active
+
+### Key Commands (TLP)
+
+```bash
+# Get current mode (based on AC/battery)
+tlp-stat -s | grep "Mode:" | awk '{print $2}'
+
+# Force AC mode (performance)
+sudo tlp ac
+
+# Force battery mode (power-saver)
+sudo tlp bat
+
+# Auto mode
+sudo tlp start
+```
+
+### Alternative (power-profiles-daemon)
+
+```bash
+# Get current profile
+powerprofilesctl get
+
+# Set profile
+powerprofilesctl set balanced
+powerprofilesctl set power-saver
+powerprofilesctl set performance
+```
+
+### Update Strategy
+- **Polling**: 5s interval (profiles change infrequently)
+- Check which tool is available at runtime
+
+---
+
+## 6. Thermal Monitoring (lm_sensors)
+
+### Decision
+Use `sensors -j` for JSON output, poll at 2s intervals.
+
+### Rationale
+- Native JSON output simplifies parsing
+- Widely available on all systems
+- Consistent interface across AMD/Intel
+
+### Key Commands
+
+```bash
+# Get all sensors as JSON
+sensors -j
+
+# Parse CPU temperature
+sensors -j | jq '.. | objects | select(.temp1_input) | .temp1_input | floor' | head -1
+
+# Get fan speeds
+sensors | grep -i "fan" | awk '{print $2}'
+```
+
+### ThinkPad Sensors
+- CPU: `coretemp-isa-0000` or `thinkpad-isa-0000`
+- Fan: `thinkpad-isa-0000` (fan1_input)
+
+### Ryzen Sensors
+- CPU: `k10temp-pci-00c3` (Tctl, Tccd1)
+- No integrated fan control (external)
+
+### Update Strategy
+- **Polling**: 2s interval (temperature changes slowly)
+
+---
+
+## 7. Network Status (nmcli)
+
+### Decision
+Use `nmcli` for status, `nmcli monitor` for events.
+
+### Rationale
+- NetworkManager is already enabled
+- Event-driven monitoring available
+- Rich WiFi information (SSID, signal strength)
+
+### Key Commands
+
+```bash
+# Get current WiFi SSID
+nmcli -t -f active,ssid dev wifi | grep "^yes" | cut -d: -f2
+
+# Get connection type
+nmcli -t -f TYPE connection show --active | head -1
+
+# Get WiFi signal strength
+nmcli dev wifi list | grep "^\*" | awk '{print $(NF-1)}'
+
+# Get Tailscale status
+tailscale status --json | jq -r '.Self.Online'
+```
+
+### Event Monitoring
+
+```bash
+# Monitor connection changes
+nmcli monitor
+```
+
+### Update Strategy
+- **Event-driven**: nmcli monitor with deflisten
+- Fallback polling: 5s interval
+
+---
+
+## Hardware Detection Strategy
+
+### Runtime Detection Pattern
+
+```nix
+# In Eww backend script
+hasBattery = builtins.pathExists "/sys/class/power_supply/BAT0";
+hasBrightness = builtins.pathExists "/sys/class/backlight";
+hasBluetooth = config.hardware.bluetooth.enable;
+hasThermalSensors = builtins.pathExists "/sys/class/hwmon";
+```
+
+### Python Detection
+
+```python
+import os
+from pathlib import Path
+
+def detect_hardware():
+    return {
+        "battery": Path("/sys/class/power_supply/BAT0").exists(),
+        "brightness": any(Path("/sys/class/backlight").iterdir()),
+        "bluetooth": Path("/sys/class/bluetooth").exists(),
+        "thermal": any(Path("/sys/class/hwmon").iterdir()),
+        "wifi": Path("/sys/class/net/wlan0").exists() or
+                Path("/sys/class/net/wlp0s20f3").exists(),
+    }
+```
+
+---
+
+## Eww Architecture Recommendations
+
+### Tier 1: Top Bar (Quick Controls)
+- Use defpoll with short intervals (1-2s)
+- Click handlers expand to reveal sliders
+- Click-outside-to-close via eventbox
+
+### Tier 2: Monitoring Panel (Full Dashboard)
+- Use defpoll with run-while (only when tab visible)
+- Longer intervals (3-5s) for detailed data
+- Keyboard navigation support
+
+### Backend Script Structure
+
+```python
+#!/usr/bin/env python3
+"""Unified device backend for Eww widgets."""
+
+import json
+import subprocess
+from dataclasses import dataclass, asdict
+
+@dataclass
+class DeviceState:
+    volume: int
+    volume_muted: bool
+    brightness: int | None
+    keyboard_brightness: int | None
+    bluetooth_enabled: bool
+    bluetooth_devices: list
+    battery_percent: int | None
+    battery_charging: bool | None
+    battery_time: str | None
+    power_profile: str | None
+    cpu_temp: int | None
+    fan_speed: int | None
+    wifi_ssid: str | None
+    tailscale_connected: bool
+
+def get_device_state() -> DeviceState:
+    # Query all devices and return unified state
+    pass
+
+if __name__ == "__main__":
+    state = get_device_state()
+    print(json.dumps(asdict(state)))
+```
+
+---
+
+## Alternatives Considered
+
+### pavucontrol for Volume
+- Rejected: GTK app (~1GB with dependencies), not suitable for Eww integration
+
+### blueman for Bluetooth
+- Rejected: GTK app (~800MB), better to use bluetoothctl directly
+
+### powerstat for Battery
+- Rejected: Not as widely available as UPower
+
+### hwinfo for Thermals
+- Rejected: Heavier than lm_sensors, no JSON output
+
+---
+
+## Sources
+
+- WirePlumber wpctl: https://pipewire.pages.freedesktop.org/wireplumber/tools/wpctl.html
+- brightnessctl: https://github.com/Hummer12007/brightnessctl
+- BlueZ D-Bus: https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc
+- UPower D-Bus: https://upower.freedesktop.org/docs/UPower.html
+- TLP Documentation: https://linrunner.de/tlp/
+- lm_sensors: https://github.com/lm-sensors/lm-sensors
+- NetworkManager nmcli: https://networkmanager.dev/docs/api/latest/nmcli.html

--- a/specs/116-use-eww-device/spec.md
+++ b/specs/116-use-eww-device/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Unified Eww Device Control Panel
+
+**Feature Branch**: `116-use-eww-device`
+**Created**: 2025-12-13
+**Status**: Draft
+**Input**: User description: "Create a feature to control device-related gauges/switches on bare metal using Eww. Determine the best placement (monitoring panel tab, top bar, etc.). Review open-source Eww examples for great UI. Integrate seamlessly, avoid duplication. Consider: Bluetooth, volume, brightness. Target ThinkPad and Ryzen machines."
+
+## Clarifications
+
+### Session 2025-12-13
+
+- Q: How should the expanded top bar device panel be dismissed? → A: Click outside panel dismisses it (click-outside-to-close)
+- Q: What is the relationship between top bar controls and monitoring panel Devices tab? → A: Top bar provides quick controls (sliders/toggles); Monitoring panel provides full dashboard with additional details
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Quick Device Access from Top Bar (Priority: P1)
+
+A developer working on their ThinkPad laptop needs to quickly adjust volume before a video call, check battery status, toggle Bluetooth to connect headphones, and reduce screen brightness as the room darkens. They want to do this without leaving their current workspace or opening a separate application.
+
+**Why this priority**: This is the core use case - fast, non-disruptive device control during active work. Top bar placement provides constant visibility and one-click access matching OS-native control center patterns users already know.
+
+**Independent Test**: Can be fully tested by clicking the device indicator in the top bar, seeing the expanded control panel, adjusting a slider, and observing the device change in real-time.
+
+**Acceptance Scenarios**:
+
+1. **Given** user is working in any application on ThinkPad, **When** they click the volume icon in the top bar, **Then** an expanded panel appears showing a volume slider with current percentage and mute toggle
+2. **Given** the volume panel is visible, **When** user drags the slider to 75%, **Then** system volume changes immediately with visual feedback confirming the new level
+3. **Given** user has Bluetooth headphones nearby, **When** they click the Bluetooth icon in the top bar, **Then** they see Bluetooth on/off toggle and a list of paired devices with connection status
+4. **Given** user is on a laptop with brightness control, **When** they click the brightness indicator, **Then** they see a slider to adjust display brightness (and keyboard backlight if present)
+5. **Given** user is on Ryzen desktop (no battery/brightness), **When** they view the top bar, **Then** only applicable controls are shown (volume, Bluetooth, network status)
+
+---
+
+### User Story 2 - Hardware-Adaptive Device Detection (Priority: P2)
+
+The user has multiple machines with different hardware capabilities: a ThinkPad laptop with battery, brightness control, fingerprint sensor, and TLP power management, versus a Ryzen desktop with neither battery nor brightness controls. The system should automatically detect available hardware and show only relevant controls.
+
+**Why this priority**: Critical for multi-machine setups to avoid UI clutter and confusion. Controls for unavailable hardware waste space and create poor UX.
+
+**Independent Test**: Can be verified by deploying the same configuration to both ThinkPad and Ryzen, observing that each shows only its available device controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** user is on ThinkPad, **When** device panel loads, **Then** battery status, brightness controls, power profile selector, and all applicable sensors are visible
+2. **Given** user is on Ryzen desktop, **When** device panel loads, **Then** only volume, Bluetooth, and network status are shown (no battery or brightness)
+3. **Given** a Bluetooth adapter is disabled or not present, **When** device panel loads, **Then** the Bluetooth control is hidden or shows "Not Available"
+4. **Given** thermal sensors are available, **When** device panel loads, **Then** temperature readings are displayed with appropriate icons
+
+---
+
+### User Story 3 - Comprehensive Device Dashboard in Monitoring Panel (Priority: P3)
+
+A user wants a full device overview for system monitoring purposes - seeing all hardware metrics, power status, sensor readings, and device states in one place alongside their existing workspace/project monitoring. They access this via the monitoring panel's dedicated "Devices" tab.
+
+**Why this priority**: Provides deep-dive capability when users need more than quick adjustments - useful for debugging hardware issues, monitoring thermals during heavy workloads, or checking detailed battery health.
+
+**Independent Test**: Can be verified by pressing Mod+M to open monitoring panel, switching to Devices tab (Alt+7), and confirming all device information is displayed in an organized hierarchy.
+
+**Acceptance Scenarios**:
+
+1. **Given** user presses Mod+M to open monitoring panel, **When** they press Alt+7 (or click Devices tab), **Then** they see comprehensive device information organized by category
+2. **Given** Devices tab is active, **When** user views audio section, **Then** they see current output device, volume level, microphone status, and can change output device
+3. **Given** Devices tab is active on ThinkPad, **When** user views power section, **Then** they see battery percentage, estimated time remaining, charging status, current power profile, and charge thresholds
+4. **Given** Devices tab is active, **When** user views sensors section, **Then** they see CPU temperature, fan speeds (if available), and thermal zone readings
+5. **Given** user is in panel focus mode (Mod+Shift+M), **When** they navigate the Devices tab, **Then** keyboard navigation (j/k/Enter) works for interacting with controls
+
+---
+
+### User Story 4 - Remove Duplicate Controls and Consolidate (Priority: P4)
+
+The user currently has device controls scattered across multiple widgets: volume in top bar, brightness in a separate quick panel (eww-quick-panel), and some controls are missing proper integration. They want a single, unified system that replaces all existing fragmented controls.
+
+**Why this priority**: Eliminates confusion from multiple entry points, reduces maintenance burden, and creates a cohesive user experience. The existing quick panel duplicates some controls and should be deprecated.
+
+**Independent Test**: Can be verified by confirming the eww-quick-panel is disabled/removed and all its controls are accessible via the new unified system.
+
+**Acceptance Scenarios**:
+
+1. **Given** user previously accessed brightness via quick panel, **When** they use the new device controls, **Then** brightness adjustment is available in both top bar expansion and monitoring panel tab
+2. **Given** the eww-quick-panel module exists, **When** the feature is complete, **Then** it is disabled by default and replaced by the unified device controls
+3. **Given** volume controls exist in top bar, **When** the feature is complete, **Then** volume remains in top bar but gains expanded slider functionality consistent with other device controls
+
+---
+
+### Edge Cases
+
+- How is the expanded device panel dismissed? Clicking outside the panel closes it (click-outside-to-close pattern matching OS-native control centers)
+- What happens when Bluetooth hardware is disabled at kernel level? Control should show "Disabled" state with option to describe how to enable
+- How does the system handle rapidly changing values (e.g., volume during media playback)? Updates should be smooth without flickering (<100ms latency)
+- What happens when a device operation fails (e.g., Bluetooth connect fails)? Clear error feedback with retry option
+- How does the system handle multiple audio output devices? Allow selection from list with clear active indicator
+- What happens when ThinkPad lid is closed (external monitor only)? Brightness controls should adapt to available displays
+- How does the system handle VPN/Tailscale connection status? Show connection state in network section
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST display device controls in an expandable panel accessible from the top bar indicators (volume, Bluetooth, battery)
+- **FR-002**: System MUST detect available hardware at runtime and show only applicable controls per machine (ThinkPad vs Ryzen)
+- **FR-003**: System MUST provide volume control with slider, percentage display, and mute toggle
+- **FR-004**: System MUST provide Bluetooth toggle (on/off) with paired device list showing connection status
+- **FR-005**: System MUST provide brightness control slider for laptop displays (when hardware is present)
+- **FR-006**: System MUST provide keyboard backlight control for laptops with backlit keyboards (ThinkPad kbd_backlight device)
+- **FR-007**: System MUST display battery percentage, charging status, and estimated time remaining on laptops
+- **FR-008**: System MUST display power profile selector (performance/balanced/power-saver) on laptops using TLP
+- **FR-009**: System MUST add a "Devices" tab (index 6, Alt+7) to the monitoring panel with comprehensive device information
+- **FR-010**: System MUST show network connection status (WiFi SSID, Tailscale connection state)
+- **FR-011**: System MUST display thermal readings (CPU temperature, fan speed where available) on bare metal machines
+- **FR-012**: System MUST integrate with existing Catppuccin Mocha theme for visual consistency
+- **FR-013**: System MUST support keyboard navigation in monitoring panel Devices tab (j/k/Enter/Escape)
+- **FR-014**: System MUST deprecate the existing eww-quick-panel module, migrating all functionality to the unified system
+- **FR-015**: System MUST use event-driven updates via deflisten where possible for <100ms latency
+- **FR-016**: System MUST show graceful "Not Available" states for hardware that is disabled or missing
+
+### Key Entities
+
+- **DeviceControl**: A hardware component that can be monitored or controlled (volume, brightness, Bluetooth, battery, thermal)
+- **DeviceState**: Current status of a device (value, enabled/disabled, connected/disconnected)
+- **HardwareProfile**: Machine-specific configuration indicating available devices (ThinkPad has battery/brightness, Ryzen does not)
+- **ControlAction**: User-initiated change to a device (set volume, toggle Bluetooth, adjust brightness)
+
+### UI Architecture (Tiered Approach)
+
+- **Top Bar (Quick Controls)**: Indicators with expandable panels for common adjustments - volume slider, brightness slider, Bluetooth toggle, battery status. Optimized for speed (<2 seconds to adjust).
+- **Monitoring Panel Devices Tab (Full Dashboard)**: Comprehensive view with all device details - output device selection, detailed battery health, charge thresholds, thermal graphs, fan speeds, power profile history. Optimized for monitoring and troubleshooting.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can access and adjust volume from any workspace within 2 seconds (one click to expand, drag slider)
+- **SC-002**: Device control panel updates in real-time with less than 100ms latency for continuous values (volume, brightness)
+- **SC-003**: Hardware detection correctly identifies available devices on both ThinkPad and Ryzen with 100% accuracy (no false controls shown)
+- **SC-004**: All device controls from the deprecated quick panel are accessible in the new unified system
+- **SC-005**: Users can navigate the Devices tab in monitoring panel using keyboard only (no mouse required) in focus mode
+- **SC-006**: The unified device controls maintain visual consistency with existing Eww widgets (Catppuccin Mocha theme, same pill styling, hover effects)
+- **SC-007**: System works offline - device controls function without network connectivity (except VPN/network status obviously)
+- **SC-008**: Memory usage for device monitoring stays under 50MB additional overhead

--- a/specs/116-use-eww-device/tasks.md
+++ b/specs/116-use-eww-device/tasks.md
@@ -1,0 +1,276 @@
+# Tasks: Unified Eww Device Control Panel
+
+**Input**: Design documents from `/specs/116-use-eww-device/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: No automated tests requested - manual verification on ThinkPad and Ryzen per spec.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md project structure:
+- **Module**: `home-modules/desktop/eww-device-controls.nix`
+- **Widgets**: `home-modules/desktop/eww-device-controls/eww.yuck.nix`
+- **Styles**: `home-modules/desktop/eww-device-controls/eww.scss.nix`
+- **Scripts**: `home-modules/desktop/eww-device-controls/scripts/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and module structure creation
+
+- [X] T001 Create module directory structure at home-modules/desktop/eww-device-controls/
+- [X] T002 Create main module skeleton in home-modules/desktop/eww-device-controls.nix with enable option and imports
+- [X] T003 [P] Create empty eww.yuck.nix with widget stubs in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T004 [P] Create eww.scss.nix with Catppuccin Mocha base styles in home-modules/desktop/eww-device-controls/eww.scss.nix
+- [X] T005 Create scripts directory structure at home-modules/desktop/eww-device-controls/scripts/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core backend infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T006 Implement HardwareCapabilities detection in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (detect battery, brightness, bluetooth, wifi, thermal sensors per data-model.md)
+- [X] T007 [P] Implement VolumeState query using wpctl in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (volume percentage, muted status, icon mapping, device list per data-model.md)
+- [X] T008 [P] Implement BluetoothState query using bluetoothctl in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (enabled status, device list with connection status per data-model.md)
+- [X] T009 [P] Create volume-control.sh wrapper script at home-modules/desktop/eww-device-controls/scripts/volume-control.sh (get/set/up/down/mute/device actions per contracts/device-backend.md)
+- [X] T010 [P] Create bluetooth-control.sh wrapper script at home-modules/desktop/eww-device-controls/scripts/bluetooth-control.sh (get/power/connect/disconnect/scan actions per contracts/device-backend.md)
+- [X] T011 Add --mode flag support to device-backend.py for selective queries (full/volume/brightness/bluetooth/battery/thermal/network per contracts/device-backend.md)
+- [X] T012 Add --listen flag support to device-backend.py for deflisten streaming mode per contracts/device-backend.md
+- [X] T013 Implement error handling and JSON error output format in all scripts per contracts/device-backend.md error codes
+
+**Checkpoint**: Foundation ready - backend scripts functional, user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Quick Device Access from Top Bar (Priority: P1) 🎯 MVP
+
+**Goal**: Volume, Bluetooth, battery controls accessible via expandable top bar panels with <2 second interaction time
+
+**Independent Test**: Click volume icon in top bar → expanded panel appears → drag slider → volume changes in real-time
+
+### Implementation for User Story 1
+
+- [X] T014 [P] [US1] Create defpoll for volume_state with 1s interval in home-modules/desktop/eww-device-controls/eww.yuck.nix using device-backend.py --mode volume
+- [X] T015 [P] [US1] Create defpoll for bluetooth_state with 3s interval in home-modules/desktop/eww-device-controls/eww.yuck.nix using device-backend.py --mode bluetooth
+- [X] T016 [US1] Create volume-indicator widget with expandable panel in home-modules/desktop/eww-device-controls/eww.yuck.nix (icon, click-to-expand, slider, mute toggle, device list)
+- [X] T017 [US1] Create bluetooth-indicator widget with expandable panel in home-modules/desktop/eww-device-controls/eww.yuck.nix (icon with connection status color, toggle switch, paired device list)
+- [X] T018 [US1] Implement click-outside-to-close behavior for expanded panels using eventbox in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T019 [US1] Add onscroll handlers to top bar indicators for quick volume/brightness adjustment in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T020 [US1] Style volume panel with Catppuccin Mocha colors (slider, mute icon states) in home-modules/desktop/eww-device-controls/eww.scss.nix
+- [X] T021 [US1] Style bluetooth panel with Catppuccin Mocha colors (toggle switch, device list, connection status) in home-modules/desktop/eww-device-controls/eww.scss.nix
+- [~] T022 [US1] DEFERRED: Integrate device indicators into existing eww-top-bar - eww-top-bar already has working volume/battery/bluetooth widgets with its own scripts. Device-controls provides value via Devices tab (Alt+7) instead. Refactoring top bar would be high-risk for minimal gain.
+- [X] T023 [US1] Add Nix package dependencies (wpctl, bluetoothctl) to home-modules/desktop/eww-device-controls.nix
+
+**Checkpoint**: User Story 1 complete - volume and Bluetooth controls work from top bar on both ThinkPad and Ryzen
+
+---
+
+## Phase 4: User Story 2 - Hardware-Adaptive Device Detection (Priority: P2)
+
+**Goal**: Only show controls for available hardware - no brightness on Ryzen, no battery on desktop
+
+**Independent Test**: Deploy same config to ThinkPad and Ryzen, verify each shows only applicable controls
+
+### Implementation for User Story 2
+
+- [X] T024 [P] [US2] Implement BrightnessState query using brightnessctl in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (display and keyboard brightness per data-model.md)
+- [X] T025 [P] [US2] Implement BatteryState query using upower in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (percentage, state, time remaining, icon mapping per data-model.md)
+- [X] T026 [P] [US2] Create brightness-control.sh wrapper script at home-modules/desktop/eww-device-controls/scripts/brightness-control.sh (get/set/up/down with --device flag per contracts/device-backend.md)
+- [X] T027 [US2] Add hardware capability flags to JSON output in device-backend.py (has_battery, has_brightness, has_keyboard_backlight, has_bluetooth, etc. per data-model.md)
+- [X] T028 [US2] Create conditional widget rendering using hardware flags in home-modules/desktop/eww-device-controls/eww.yuck.nix (show brightness only if has_brightness, battery only if has_battery)
+- [X] T029 [P] [US2] Create brightness-indicator widget with expandable panel in home-modules/desktop/eww-device-controls/eww.yuck.nix (display slider, keyboard slider if available)
+- [X] T030 [P] [US2] Create battery-indicator widget in home-modules/desktop/eww-device-controls/eww.yuck.nix (icon based on level/charging state, click to expand for time remaining)
+- [X] T031 [US2] Style brightness and battery panels with Catppuccin Mocha colors in home-modules/desktop/eww-device-controls/eww.scss.nix
+- [X] T032 [US2] Add defpoll for brightness_state (2s interval, only when has_brightness) in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T033 [US2] Add defpoll for battery_state (5s interval, only when has_battery) in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T034 [US2] Implement "Not Available" graceful fallback state display for disabled/missing hardware in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T035 [US2] Add Nix package dependencies (brightnessctl, upower) to home-modules/desktop/eww-device-controls.nix
+
+**Checkpoint**: User Story 2 complete - ThinkPad shows all controls, Ryzen shows only applicable ones
+
+---
+
+## Phase 5: User Story 3 - Comprehensive Device Dashboard in Monitoring Panel (Priority: P3)
+
+**Goal**: Full device overview in monitoring panel Devices tab (index 6, Alt+7) with all metrics and keyboard navigation
+
+**Independent Test**: Press Mod+M → Alt+7 → see comprehensive device info organized by category, navigate with j/k/Enter
+
+### Implementation for User Story 3
+
+- [X] T036 [P] [US3] Implement ThermalState query using lm_sensors in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (CPU temp, fan speed, thermal zones per data-model.md)
+- [X] T037 [P] [US3] Implement NetworkState query using nmcli and tailscale in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (WiFi SSID, signal strength, Tailscale status per data-model.md)
+- [X] T038 [P] [US3] Implement PowerProfileState query using TLP or power-profiles-daemon in device-backend.py at home-modules/desktop/eww-device-controls/scripts/device-backend.py (current profile, available profiles per data-model.md)
+- [X] T039 [P] [US3] Create power-profile-control.sh wrapper script at home-modules/desktop/eww-device-controls/scripts/power-profile-control.sh (get/set/cycle actions per contracts/device-backend.md)
+- [X] T040 [US3] Create devices-tab widget definition in home-modules/desktop/eww-device-controls/eww.yuck.nix with sections: Audio, Display, Bluetooth, Power, Thermal, Network
+- [X] T041 [US3] Create audio section widget with output device selector, volume slider, microphone status in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T042 [P] [US3] Create display section widget with brightness sliders (display + keyboard backlight) in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T043 [P] [US3] Create bluetooth section widget with adapter toggle and full paired device list in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T044 [US3] Create power section widget with battery details (health, cycles, power draw), charging status, power profile selector in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T045 [P] [US3] Create thermal section widget with CPU temperature, fan speed, thermal zone readings in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T046 [P] [US3] Create network section widget with WiFi status/SSID/signal and Tailscale connection status in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T047 [US3] Implement keyboard navigation (j/k/Enter/Escape) for devices-tab in focus mode in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T048 [US3] Style devices-tab sections with Catppuccin Mocha theme, consistent with existing monitoring panel tabs in home-modules/desktop/eww-device-controls/eww.scss.nix
+- [X] T049 [US3] Add defpoll for full device_state (2s interval, run-while Devices tab visible) in home-modules/desktop/eww-device-controls/eww.yuck.nix
+- [X] T050 [US3] Integrate Devices tab into eww-monitoring-panel at index 6 (Alt+7) by updating home-modules/desktop/eww-monitoring-panel.nix
+- [X] T051 [US3] Add Nix package dependencies (lm_sensors, tailscale CLI) to home-modules/desktop/eww-device-controls.nix
+
+**Checkpoint**: User Story 3 complete - Devices tab provides comprehensive dashboard with keyboard navigation
+
+---
+
+## Phase 6: User Story 4 - Remove Duplicate Controls and Consolidate (Priority: P4)
+
+**Goal**: Deprecate eww-quick-panel, migrate all functionality to unified system, eliminate duplication
+
+**Independent Test**: Verify eww-quick-panel is disabled, all its controls accessible via new system
+
+### Implementation for User Story 4
+
+- [X] T052 [US4] Audit existing eww-quick-panel module at home-modules/desktop/eww-quick-panel.nix to identify all controls that must be migrated
+- [X] T053 [US4] Verify all eww-quick-panel controls are present in unified device controls (brightness, audio, etc.)
+- [X] T054 [US4] Update eww-quick-panel.nix to set enable = mkDefault false (deprecate but don't remove)
+- [X] T055 [US4] Add deprecation comment and migration guidance to eww-quick-panel.nix pointing to eww-device-controls
+- [~] T056 [US4] DEFERRED: Top bar already uses its own volume-status.sh/volume-monitor.py scripts. Device-controls and top bar are intentionally separate Eww instances to avoid conflicts.
+- [X] T057 [US4] Verify no duplicate defpoll or deflisten - VERIFIED: device-controls uses device-backend.py in separate Eww config (~/.config/eww/eww-device-controls/), top bar uses its own scripts (~/.config/eww/eww-top-bar/scripts/). No conflicts.
+- [ ] T058 [US4] MANUAL: Test unified controls on ThinkPad - verify Devices tab (Alt+7) shows all sections
+- [ ] T059 [US4] MANUAL: Test unified controls on Ryzen - verify Devices tab shows only applicable sections (no brightness/battery)
+
+**Checkpoint**: User Story 4 complete - eww-quick-panel deprecated, all controls unified, no duplication
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, performance optimization, and final validation
+
+- [X] T060 [P] Validate quickstart.md scenarios match actual implementation in specs/116-use-eww-device/quickstart.md
+- [ ] T061 [P] MANUAL: Verify <100ms latency for volume/brightness updates using deflisten mode
+- [ ] T062 MANUAL: Verify memory usage stays under 50MB additional overhead (SC-008)
+- [ ] T063 MANUAL: Run full manual test on ThinkPad per acceptance scenarios in spec.md
+- [ ] T064 MANUAL: Run full manual test on Ryzen per acceptance scenarios in spec.md
+- [X] T065 Update CLAUDE.md with Devices tab keybindings (Alt+7) and new device control documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - User stories can then proceed in priority order (P1 → P2 → P3 → P4)
+  - Some parallelization possible within stories
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - Core top bar controls (volume, bluetooth)
+- **User Story 2 (P2)**: Can start after Foundational - Adds brightness, battery, hardware detection
+- **User Story 3 (P3)**: Can start after US1/US2 - Adds monitoring panel Devices tab
+- **User Story 4 (P4)**: Should start after US1/US2/US3 complete - Deprecation and consolidation
+
+### Within Each User Story
+
+- Backend scripts before widget implementation
+- Widgets before styling
+- Core functionality before integration with existing modules
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks T003-T004 can run in parallel
+- Foundational tasks T007-T010 can run in parallel (different scripts)
+- Within US1: T014-T015 (defpolls) in parallel, T020-T021 (styles) in parallel
+- Within US2: T024-T026 (backend) in parallel, T029-T030 (widgets) in parallel
+- Within US3: T036-T039 (backend) in parallel, T042-T046 (section widgets) in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch defpolls together:
+Task: T014 "defpoll for volume_state"
+Task: T015 "defpoll for bluetooth_state"
+
+# Launch styles together (after widgets):
+Task: T020 "Style volume panel"
+Task: T021 "Style bluetooth panel"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch all backend queries together:
+Task: T036 "ThermalState query"
+Task: T037 "NetworkState query"
+Task: T038 "PowerProfileState query"
+Task: T039 "power-profile-control.sh wrapper"
+
+# Launch section widgets together (after main devices-tab structure):
+Task: T042 "Display section widget"
+Task: T043 "Bluetooth section widget"
+Task: T045 "Thermal section widget"
+Task: T046 "Network section widget"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - backend scripts)
+3. Complete Phase 3: User Story 1 (volume + bluetooth top bar controls)
+4. **STOP and VALIDATE**: Test on both ThinkPad and Ryzen
+5. Deploy if ready - core device controls functional
+
+### Incremental Delivery
+
+1. Setup + Foundational → Backend ready
+2. Add User Story 1 → Test → Deploy (MVP: volume + bluetooth)
+3. Add User Story 2 → Test → Deploy (brightness + battery + hardware detection)
+4. Add User Story 3 → Test → Deploy (Devices tab in monitoring panel)
+5. Add User Story 4 → Test → Deploy (deprecate quick-panel, cleanup)
+6. Polish → Final validation → Feature complete
+
+### Key Files Summary
+
+| Component | File Path |
+|-----------|-----------|
+| Main module | home-modules/desktop/eww-device-controls.nix |
+| Widget definitions | home-modules/desktop/eww-device-controls/eww.yuck.nix |
+| Widget styles | home-modules/desktop/eww-device-controls/eww.scss.nix |
+| Backend script | home-modules/desktop/eww-device-controls/scripts/device-backend.py |
+| Volume control | home-modules/desktop/eww-device-controls/scripts/volume-control.sh |
+| Brightness control | home-modules/desktop/eww-device-controls/scripts/brightness-control.sh |
+| Bluetooth control | home-modules/desktop/eww-device-controls/scripts/bluetooth-control.sh |
+| Power profile control | home-modules/desktop/eww-device-controls/scripts/power-profile-control.sh |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Manual testing required on both ThinkPad and Ryzen per spec


### PR DESCRIPTION
## Summary
- Implements comprehensive device control system for Eww monitoring panel
- Adds new `eww-device-controls` module with modular widget architecture
- Integrates Devices tab with Audio, Display, Bluetooth, Power, Thermal, Network sections

## Changes
- **New module**: `home-modules/desktop/eww-device-controls/` with:
  - Python backend for real-time device state polling (500ms refresh)
  - Control scripts for brightness, volume, bluetooth, power profiles
  - Modular yuck widget definitions for indicators and sections
  - GTK3 CSS with Catppuccin Mocha theming

- **Monitoring panel updates**:
  - Stack widget for proper tab switching (fixes overlay visibility issues)
  - Devices tab integration with full device state
  - Fixed initial value for devices_state to prevent null errors

- **Key fixes**:
  - Brightness slider argument parsing bug
  - Bluetooth output suppression (silent toggle)
  - Power profile using ThinkPad platform_profile instead of TLP
  - GTK3 button colors with `background-image: none`

## Test plan
- [x] Brightness slider adjusts screen brightness
- [x] Volume slider adjusts audio volume
- [x] Bluetooth toggle enables/disables bluetooth
- [x] Power profile buttons change platform profile
- [x] Tab switching works correctly
- [x] Polling updates state within 500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)