### PR TITLE
feat(tracing): synthesize Codex + Gemini traces

### DIFF
--- a/codex-config.md
+++ b/codex-config.md
@@ -1,0 +1,74 @@
+# Codex CLI config + telemetry (notes for tracing)
+
+Codex CLI currently emits **OpenTelemetry log events** (OTLP Logs) but **does not emit rich OTLP traces** comparable to Claude Code’s native traces + our Node payload interceptor.
+
+This document captures the Codex-side signals we can use to synthesize traces and mirror our Claude Code tracing strategy.
+
+## 1) What Codex emits (OTEL logs)
+
+Codex exports OTEL **log records** (not spans) when `[otel]` is enabled in `~/.codex/config.toml`.
+
+### Common metadata (present on all events)
+
+- `conversation.id` (session identifier)
+- `event.timestamp` (ISO string)
+- `event.name` (e.g. `codex.api_request`)
+- `service.name` (resource attribute; e.g. `codex_cli_rs`, `codex_tui`, `codex_exec`)
+- `service.version` / `app.version`
+- `terminal.type`, `model`, `slug`
+- Identity fields (when available): `auth_mode`, `user.account_id`, `user.email`
+
+### Event catalog
+
+- `codex.conversation_starts`
+  - `provider_name`, `reasoning_effort` (optional), `approval_policy`, `sandbox_policy`, `mcp_servers`, …
+- `codex.user_prompt`
+  - `prompt_length`, `prompt` (only if `otel.log_user_prompt = true`)
+- `codex.api_request`
+  - `attempt`, `duration_ms`, `http.response.status_code` (optional), `error.message` (failures)
+- `codex.sse_event`
+  - `event.kind` (notably `response.completed`)
+  - Token counts on `response.completed`: `input_token_count`, `output_token_count`, `cached_token_count` (optional), `reasoning_token_count` (optional), `tool_token_count`
+- `codex.tool_decision`
+  - `tool_name`, `call_id`, `decision`, `source`
+- `codex.tool_result`
+  - `tool_name`, `call_id` (optional), `arguments` (optional), `duration_ms`, `success`, `output`
+
+## 2) Hooks we can use (Codex `notify`)
+
+Codex supports a top-level `notify` hook:
+
+```toml
+notify = ["node", "/absolute/path/to/notify.js"]
+```
+
+Codex invokes this external program with **one JSON argument** per supported notification event.
+
+Currently:
+- `notify` emits **only** `agent-turn-complete` (turn boundary signal).
+
+The JSON payload includes:
+- `type` = `agent-turn-complete`
+- `thread-id` (Codex session id; correlates with `conversation.id`)
+- `cwd` (absolute project dir)
+- `last-assistant-message` (optional)
+- `input-messages` (optional)
+
+## 3) Tracing strategy (Claude-like) for Codex
+
+To mirror our Claude Code trace hierarchy:
+
+- **Session span (CHAIN)**: created from `codex.conversation_starts`, ended on idle timeout.
+- **Turn span (AGENT)**: start on `codex.user_prompt`, end on `notify` (`agent-turn-complete`), fallback to idle timeout.
+- **LLM spans (LLM/CLIENT)**: start/end derived from `codex.api_request.duration_ms`, token counts attached from `codex.sse_event` `response.completed`.
+- **Tool spans (TOOL)**: created from `codex.tool_result.duration_ms`, enriched with `codex.tool_decision` by `call_id` when available.
+
+To keep the same join key as Claude traces, we treat:
+- `session.id = conversation.id` (and inject this into forwarded Codex logs).
+
+## 4) Where this is implemented in this repo
+
+- OTEL log → trace synthesis: `scripts/codex-otel-interceptor.js`
+- Codex notify hook handler: `scripts/codex-hooks/notify.js`
+- Codex config + user service wiring: `home-modules/ai-assistants/codex.nix`
+

--- a/docs/AI_TRACING_GRAFANA.md
+++ b/docs/AI_TRACING_GRAFANA.md
@@ -2,6 +2,15 @@
 
 This repo collects Claude Code telemetry via Grafana Alloy and exports to an LGTM stack (Tempo/Mimir/Loki).
 
+## Codex CLI note (traces are synthesized)
+
+Codex CLI currently emits **OTEL log events** (not spans) via `[otel]` in `~/.codex/config.toml`.
+
+To get Claude-like traces (Session → Turn → LLM/Tool), we:
+- Route Codex OTLP logs through `scripts/codex-otel-interceptor.js` (it forwards logs to Alloy and **synthesizes OTLP traces**).
+- Use Codex’s `notify` hook to post `agent-turn-complete` to the interceptor for accurate turn end boundaries.
+- Normalize the join key by copying `conversation.id` → `session.id` in forwarded Codex logs, and using the same `session.id` on synthesized spans.
+
 ## 1) The join key: `session.id`
 
 Claude Code native OpenTelemetry telemetry uses `session.id` (UUID per conversation).

--- a/docs/AI_TRACING_GRAFANA.md
+++ b/docs/AI_TRACING_GRAFANA.md
@@ -11,6 +11,14 @@ To get Claude-like traces (Session → Turn → LLM/Tool), we:
 - Use Codex’s `notify` hook to post `agent-turn-complete` to the interceptor for accurate turn end boundaries.
 - Normalize the join key by copying `conversation.id` → `session.id` in forwarded Codex logs, and using the same `session.id` on synthesized spans.
 
+## Gemini CLI note (traces are synthesized)
+
+Gemini CLI emits OTLP/HTTP **JSON** logs/metrics/traces, but posts them to `/` as OTLP “envelopes” (not `/v1/*`), and its native spans are currently low-signal.
+
+To get Claude-like traces (Session → Turn → LLM/Tool), we:
+- Route Gemini OTLP envelopes through `scripts/gemini-otel-interceptor.js` (it forwards logs/metrics to the collector and **synthesizes OTLP traces**).
+- Use log events (`gemini_cli.user_prompt`, `gemini_cli.api_*`, `gemini_cli.tool_call`) for span boundaries (Gemini currently has no notify hook like Codex).
+
 ## 1) The join key: `session.id`
 
 Claude Code native OpenTelemetry telemetry uses `session.id` (UUID per conversation).

--- a/gemini-config.md
+++ b/gemini-config.md
@@ -1,0 +1,56 @@
+# Gemini CLI telemetry (notes for tracing)
+
+Gemini CLI emits OpenTelemetry (OTLP) **log events** with high-signal `event.name` values, but its native OTLP traces are currently low-signal (generic HTTP auto-instrumentation spans like `POST`).
+
+To mirror our Claude Code + Codex tracing model (Session → Turn → LLM/Tool), we synthesize traces from Gemini’s structured log events and export them via OTLP/HTTP.
+
+## 1) What Gemini emits (OTEL logs / metrics / traces)
+
+Gemini CLI sends OTLP/HTTP **JSON** payloads, but (importantly) posts them to `/` as “OTLP envelopes”:
+
+- Logs payloads: `{ "resourceLogs": [...] }`
+- Metrics payloads: `{ "resourceMetrics": [...] }`
+- Traces payloads: `{ "resourceSpans": [...] }` (usually low-signal today)
+
+### Common metadata (present on all log events)
+
+- `session.id` (primary join key)
+- `installation.id`
+- `interactive` (bool)
+- `user.email` (if available)
+- `event.timestamp` (ISO string)
+- `event.name` (e.g. `gemini_cli.api_response`)
+
+### Key log events (per `https://gemini-cli-docs.pages.dev/telemetry`)
+
+- `gemini_cli.config`
+  - model + runtime config: `model`, `sandbox_enabled`, `approval_mode`, `mcp_servers`, …
+- `gemini_cli.user_prompt`
+  - `prompt_id`, `prompt_length`, `prompt` (if `logPrompts` enabled)
+- `gemini_cli.api_request`
+  - `model`, `prompt_id`, `request_text` (may include working directory)
+- `gemini_cli.api_response`
+  - `duration_ms`, token counts: `input_token_count`, `output_token_count`, `cached_content_token_count`, `thoughts_token_count`, `tool_token_count`, `total_token_count`, plus `status_code`
+- `gemini_cli.api_error`
+  - `error`, `error_type`, `status_code`, `latency_ms`, `prompt_id`
+- `gemini_cli.tool_call`
+  - `function_name`, `function_args`, `duration_ms`, `status`, `decision`, `error`, `error_type`
+
+## 2) Tracing strategy (Claude/Codex-like) for Gemini
+
+We synthesize spans from log events:
+
+- **Session span (CHAIN)**: created on first event for a `session.id`, ended on idle timeout.
+- **Turn span (AGENT)**: start on `gemini_cli.user_prompt`, end via idle debounce (Gemini has no `notify`/hook equivalent today).
+- **LLM spans (LLM/CLIENT)**: from `gemini_cli.api_response` / `gemini_cli.api_error`, enriched with `gemini_cli.api_request` where available.
+- **Tool spans (TOOL)**: from `gemini_cli.tool_call`.
+
+Join key alignment:
+
+- Gemini already uses `session.id`; the interceptor also copies it into `conversation.id` and `gen_ai.conversation.id` on forwarded logs for parity with our Codex/Claude conventions.
+
+## 3) Where this is implemented in this repo
+
+- OTLP envelope forwarder + log→trace synthesis: `scripts/gemini-otel-interceptor.js`
+- Gemini config + user service wiring: `home-modules/ai-assistants/gemini-cli.nix`
+

--- a/home-modules/ai-assistants/codex.nix
+++ b/home-modules/ai-assistants/codex.nix
@@ -1,6 +1,8 @@
 { config, pkgs, lib, pkgs-unstable ? pkgs, ... }:
 
 let
+  repoRoot = ../../.;
+
   # Chromium is only available on Linux
   # On Darwin, MCP servers requiring Chromium will be disabled
   enableChromiumMcpServers = pkgs.stdenv.isLinux;
@@ -8,6 +10,11 @@ let
   chromiumConfig = lib.optionalAttrs enableChromiumMcpServers {
     chromiumBin = "${pkgs.chromium}/bin/chromium";
   };
+
+  # Codex OTEL log interceptor (Codex emits OTEL logs, not traces)
+  # We synthesize traces from log events and export them via OTLP/HTTP to Alloy.
+  codexOtelInterceptorHost = "127.0.0.1";
+  codexOtelInterceptorPort = 4319;
 
   # Wrapper for codex that sets OTEL batch processor env vars for real-time export
   codexPackage = pkgs-unstable.codex or pkgs.codex;
@@ -100,12 +107,20 @@ in
         log_user_prompt = true;  # Enable for debugging (disable in production)
         exporter = {
           otlp-http = {
-            endpoint = "http://localhost:4318/v1/logs";
+            # Send Codex OTLP *logs* to local interceptor (it forwards to Alloy)
+            endpoint = "http://${codexOtelInterceptorHost}:${toString codexOtelInterceptorPort}/v1/logs";
             traces_endpoint = "http://localhost:4318/v1/traces";
             protocol = "json";  # Use JSON for compatibility with our receiver
           };
         };
       };
+
+      # Codex hook: external program invoked on certain lifecycle events.
+      # Used for explicit Turn completion boundaries (agent-turn-complete).
+      notify = [
+        "${pkgs.nodejs}/bin/node"
+        "${repoRoot}/scripts/codex-hooks/notify.js"
+      ];
 
       # MCP Servers configuration
       # Note: Codex does NOT support a `disabled` flag for MCP servers
@@ -162,6 +177,17 @@ in
       TEMP=$(${pkgs.coreutils}/bin/mktemp)
       ${pkgs.coreutils}/bin/cat "$CONFIG" > "$TEMP"
 
+      # Feature 126: Ensure notify hook is configured at the TOML root.
+      # (In TOML, root keys must appear before any `[table]` headers.)
+      if ! ${pkgs.gnugrep}/bin/grep -q '^notify[[:space:]]*=' "$TEMP"; then
+        TEMP2=$(${pkgs.coreutils}/bin/mktemp)
+        ${pkgs.gawk}/bin/awk \
+          -v line='notify = ["${pkgs.nodejs}/bin/node", "${repoRoot}/scripts/codex-hooks/notify.js"]' \
+          'BEGIN{inserted=0} /^[[:space:]]*\\[/{ if(!inserted){ print line; inserted=1 } } { print } END{ if(!inserted){ print line } }' \
+          "$TEMP" > "$TEMP2"
+        ${pkgs.coreutils}/bin/mv "$TEMP2" "$TEMP"
+      fi
+
       # Only add OTEL if not already present
       if ! ${pkgs.gnugrep}/bin/grep -q '^\[otel\]' "$TEMP"; then
         ${pkgs.coreutils}/bin/cat >> "$TEMP" << 'EOF'
@@ -172,7 +198,7 @@ environment = "dev"
 log_user_prompt = true
 
 [otel.exporter.otlp-http]
-endpoint = "http://localhost:4318/v1/logs"
+endpoint = "http://${codexOtelInterceptorHost}:${toString codexOtelInterceptorPort}/v1/logs"
 traces_endpoint = "http://localhost:4318/v1/traces"
 protocol = "json"
 EOF
@@ -184,4 +210,35 @@ EOF
       ${pkgs.coreutils}/bin/chmod 600 "$CONFIG"
     fi
   '';
+
+  # Feature 126: Codex OTEL interceptor (local user service)
+  systemd.user.services.codex-otel-interceptor = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Codex OTEL interceptor (synthesize traces from Codex log events)";
+      After = [ "default.target" ];
+      PartOf = [ "default.target" ];
+    };
+
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.nodejs}/bin/node ${repoRoot}/scripts/codex-otel-interceptor.js";
+      Restart = "on-failure";
+      RestartSec = 2;
+
+      # Ensure predictable networking + endpoints
+      Environment = [
+        "CODEX_OTEL_INTERCEPTOR_HOST=${codexOtelInterceptorHost}"
+        "CODEX_OTEL_INTERCEPTOR_PORT=${toString codexOtelInterceptorPort}"
+        "CODEX_OTEL_INTERCEPTOR_FORWARD_BASE=http://127.0.0.1:4318"
+      ];
+
+      StandardOutput = "journal";
+      StandardError = "journal";
+      SyslogIdentifier = "codex-otel-interceptor";
+    };
+
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 }

--- a/modules/services/otel-ai-collector.nix
+++ b/modules/services/otel-ai-collector.nix
@@ -122,9 +122,12 @@ in
             "otlphttp/k8s" = {
               endpoint = "${cfg.k8sExporterEndpoint}";
               encoding = "json";
-              # Use client certificates for mTLS authentication
+              # Tailscale Serve endpoints use publicly trusted certificates (e.g. Let's Encrypt).
+              # Do NOT override the server CA bundle here, otherwise Go TLS will ignore the system
+              # trust store and verification will fail.
+              #
+              # Keep client cert/key for optional mTLS (only sent if the server requests it).
               tls = {
-                ca_file = "/etc/otel/certs/ca.crt";
                 cert_file = "/etc/otel/certs/client.crt";
                 key_file = "/etc/otel/certs/client.key";
                 insecure = false;

--- a/scripts/codex-hooks/notify.js
+++ b/scripts/codex-hooks/notify.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Codex `notify` hook handler.
+ *
+ * Codex calls: notify = ["node", "/path/to/notify.js"]
+ * and passes a single JSON argument (string) describing the event.
+ *
+ * We forward that JSON to the local `codex-otel-interceptor` so it can end Turn spans.
+ *
+ * This script must never fail Codex runs, so all errors are swallowed.
+ */
+
+'use strict';
+
+const http = require('node:http');
+
+const payload = process.argv[2];
+if (!payload || typeof payload !== 'string') {
+  process.exit(0);
+}
+
+const host = process.env.CODEX_OTEL_INTERCEPTOR_HOST || '127.0.0.1';
+const port = Number.parseInt(process.env.CODEX_OTEL_INTERCEPTOR_PORT || '4319', 10);
+
+try {
+  const req = http.request(
+    {
+      hostname: host,
+      port,
+      path: '/notify',
+      method: 'POST',
+      agent: false,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    },
+    (res) => res.resume()
+  );
+  req.on('error', () => {});
+  req.setTimeout(1000, () => req.destroy());
+  req.end(payload);
+} catch {
+  // best-effort only
+}
+

--- a/scripts/codex-otel-interceptor.js
+++ b/scripts/codex-otel-interceptor.js
@@ -1,0 +1,825 @@
+#!/usr/bin/env node
+/**
+ * codex-otel-interceptor.js
+ *
+ * Codex CLI emits OpenTelemetry *log events* (not traces). This interceptor:
+ *   1) Receives Codex OTLP/HTTP log exports (JSON) on a local port
+ *   2) Forwards the logs to Grafana Alloy (or any OTLP receiver)
+ *   3) Synthesizes OpenInference-style traces (Session → Turn → LLM/Tool) and exports
+ *      them to the OTLP traces endpoint.
+ *
+ * Turn boundaries:
+ * - Start: `codex.user_prompt` log event
+ * - End: Codex `notify` hook ("agent-turn-complete") posted to `/notify`
+ * - Fallback: idle timer after last Codex event
+ */
+
+'use strict';
+
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const zlib = require('node:zlib');
+
+// =============================================================================
+// Config
+// =============================================================================
+
+const INTERCEPTOR_VERSION = '0.1.0';
+
+const LISTEN_HOST = process.env.CODEX_OTEL_INTERCEPTOR_HOST || '127.0.0.1';
+const LISTEN_PORT = Number.parseInt(process.env.CODEX_OTEL_INTERCEPTOR_PORT || '4319', 10);
+
+const FORWARD_BASE =
+  process.env.CODEX_OTEL_INTERCEPTOR_FORWARD_BASE
+  || process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+  || 'http://127.0.0.1:4318';
+
+const FORWARD_LOGS_ENDPOINT =
+  process.env.CODEX_OTEL_INTERCEPTOR_FORWARD_LOGS_ENDPOINT
+  || `${FORWARD_BASE.replace(/\/$/, '')}/v1/logs`;
+
+const TRACES_ENDPOINT =
+  process.env.CODEX_OTEL_INTERCEPTOR_TRACES_ENDPOINT
+  || process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  || `${FORWARD_BASE.replace(/\/$/, '')}/v1/traces`;
+
+const SESSION_IDLE_END_MS = Number.parseInt(
+  process.env.CODEX_OTEL_INTERCEPTOR_SESSION_IDLE_END_MS || `${10 * 60 * 1000}`,
+  10
+); // default: 10 minutes
+
+const TURN_IDLE_END_MS = Number.parseInt(
+  process.env.CODEX_OTEL_INTERCEPTOR_TURN_IDLE_END_MS || '15000',
+  10
+); // default: 15 seconds (fallback only; prefer notify hook)
+
+const DEBUG = process.env.CODEX_OTEL_INTERCEPTOR_DEBUG === '1';
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+function logDebug(...args) {
+  if (!DEBUG) return;
+  // eslint-disable-next-line no-console
+  console.error('[codex-otel-interceptor]', ...args);
+}
+
+function msToNanos(ms) {
+  return (Math.max(0, Math.floor(ms)) * 1_000_000).toString();
+}
+
+function randomHex(bytes) {
+  return crypto.randomBytes(bytes).toString('hex');
+}
+
+function getPreview(text, maxLen = 80) {
+  if (!text || typeof text !== 'string') return '';
+  const clean = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, Math.max(0, maxLen - 3)) + '...';
+}
+
+function anyValueToJs(value) {
+  if (!value || typeof value !== 'object') return null;
+  if (Object.prototype.hasOwnProperty.call(value, 'stringValue')) return value.stringValue;
+  if (Object.prototype.hasOwnProperty.call(value, 'intValue')) {
+    const n = Number.parseInt(value.intValue, 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'doubleValue')) return Number(value.doubleValue);
+  if (Object.prototype.hasOwnProperty.call(value, 'boolValue')) return Boolean(value.boolValue);
+  return null;
+}
+
+function attrFind(attributes, key) {
+  if (!Array.isArray(attributes)) return null;
+  return attributes.find((a) => a && a.key === key) || null;
+}
+
+function attrGet(attributes, key) {
+  const a = attrFind(attributes, key);
+  return a ? anyValueToJs(a.value) : null;
+}
+
+function attrGetString(attributes, key) {
+  const a = attrFind(attributes, key);
+  if (!a || !a.value) return null;
+  if (Object.prototype.hasOwnProperty.call(a.value, 'stringValue')) return a.value.stringValue;
+  if (Object.prototype.hasOwnProperty.call(a.value, 'intValue')) return String(a.value.intValue);
+  return null;
+}
+
+function attrUpsert(attributes, key, value) {
+  if (!Array.isArray(attributes)) return;
+  const existing = attrFind(attributes, key);
+  if (existing) {
+    existing.value = value;
+    return;
+  }
+  attributes.push({ key, value });
+}
+
+function parseIsoToMs(iso) {
+  if (!iso || typeof iso !== 'string') return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function parseDurationMs(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.max(0, Math.floor(value));
+  if (typeof value === 'string') {
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) ? Math.max(0, n) : null;
+  }
+  return null;
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function maybeGunzip(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length < 2) return buf;
+  if (buf[0] === 0x1f && buf[1] === 0x8b) {
+    try {
+      return zlib.gunzipSync(buf);
+    } catch {
+      return buf;
+    }
+  }
+  return buf;
+}
+
+function httpPostJson(urlStr, obj, { timeoutMs = 2000 } = {}) {
+  try {
+    const data = Buffer.from(JSON.stringify(obj));
+    const u = new URL(urlStr);
+    const mod = u.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      {
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'https:' ? 443 : 80),
+        path: u.pathname + (u.search || ''),
+        method: 'POST',
+        agent: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': data.length,
+        },
+      },
+      (res) => res.resume()
+    );
+    req.on('error', () => {});
+    req.setTimeout(timeoutMs, () => req.destroy());
+    req.end(data);
+  } catch {
+    // best-effort
+  }
+}
+
+function jsonOk(res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end('{}');
+}
+
+// =============================================================================
+// Trace synthesis state
+// =============================================================================
+
+function newSession(conversationId, meta) {
+  return {
+    conversationId,
+    traceId: randomHex(16),
+    rootSpanId: randomHex(8),
+    startTimeMs: meta.timestampMs || Date.now(),
+    lastEventTimeMs: meta.timestampMs || Date.now(),
+    serviceName: meta.serviceName || 'codex',
+    serviceVersion: meta.serviceVersion || meta.appVersion || 'unknown',
+    env: meta.env || 'dev',
+    terminalType: meta.terminalType || null,
+    model: meta.model || null,
+    providerName: meta.providerName || 'openai',
+    reasoningEffort: meta.reasoningEffort || null,
+    approvalPolicy: meta.approvalPolicy || null,
+    sandboxPolicy: meta.sandboxPolicy || null,
+    mcpServers: meta.mcpServers || null,
+    cwd: meta.cwd || null,
+
+    turnCount: 0,
+    apiCallCount: 0,
+    llmRequestSeq: 0,
+
+    tokens: {
+      input: 0,
+      output: 0,
+      cached: 0,
+      reasoning: 0,
+      tool: 0,
+    },
+
+    currentTurn: null,
+    pendingLlmCalls: [],
+    pendingToolDecisions: new Map(),
+
+    timers: {
+      sessionIdle: null,
+      turnIdle: null,
+    },
+  };
+}
+
+const state = {
+  sessions: new Map(), // conversationId -> session
+};
+
+function scheduleSessionIdleFlush(session) {
+  if (session.timers.sessionIdle) clearTimeout(session.timers.sessionIdle);
+  session.timers.sessionIdle = setTimeout(() => {
+    finalizeSession(session.conversationId, 'idle_timeout');
+  }, SESSION_IDLE_END_MS);
+}
+
+function scheduleTurnIdleFallback(session) {
+  if (session.timers.turnIdle) {
+    clearTimeout(session.timers.turnIdle);
+    session.timers.turnIdle = null;
+  }
+
+  // Only apply idle fallback when there's an active turn and no in-flight activity
+  // that would otherwise make the turn look "idle" (e.g., a long-running tool).
+  if (!session.currentTurn) return;
+  if (session.pendingLlmCalls.length > 0) return;
+  for (const v of session.pendingToolDecisions.values()) {
+    if (v && v.blocksTurnEnd) return;
+  }
+
+  session.timers.turnIdle = setTimeout(() => {
+    finalizeTurn(session.conversationId, Date.now(), 'idle_timeout');
+  }, TURN_IDLE_END_MS);
+}
+
+function baseSpanAttrs(session) {
+  return [
+    { key: 'gen_ai.system', value: { stringValue: session.providerName || 'openai' } },
+    { key: 'gen_ai.provider.name', value: { stringValue: session.providerName || 'openai' } },
+    { key: 'gen_ai.conversation.id', value: { stringValue: session.conversationId } },
+    { key: 'conversation.id', value: { stringValue: session.conversationId } },
+    { key: 'session.id', value: { stringValue: session.conversationId } },
+  ];
+}
+
+function spanStatusOk() {
+  return { code: 'STATUS_CODE_OK' };
+}
+
+function spanStatusError(message = '') {
+  return { code: 'STATUS_CODE_ERROR', message };
+}
+
+function makeSpanRecord(session, span) {
+  const resourceAttrs = [
+    { key: 'service.name', value: { stringValue: session.serviceName || 'codex' } },
+    { key: 'service.version', value: { stringValue: session.serviceVersion || 'unknown' } },
+    { key: 'codex.interceptor.version', value: { stringValue: INTERCEPTOR_VERSION } },
+    { key: 'host.name', value: { stringValue: os.hostname() } },
+    { key: 'os.type', value: { stringValue: os.platform() } },
+    { key: 'process.pid', value: { intValue: process.pid.toString() } },
+    { key: 'service.instance.id', value: { stringValue: os.hostname() } },
+    { key: 'env', value: { stringValue: session.env || 'dev' } },
+    { key: 'deployment.environment', value: { stringValue: session.env || 'dev' } },
+  ];
+
+  if (session.cwd) {
+    resourceAttrs.push({ key: 'working_directory', value: { stringValue: session.cwd } });
+  }
+  if (session.terminalType) {
+    resourceAttrs.push({ key: 'terminal.type', value: { stringValue: session.terminalType } });
+  }
+
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: resourceAttrs },
+        scopeSpans: [
+          {
+            scope: { name: 'codex-otel-interceptor', version: INTERCEPTOR_VERSION },
+            spans: [span],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function exportSpan(session, span) {
+  const record = makeSpanRecord(session, span);
+  httpPostJson(TRACES_ENDPOINT, record);
+}
+
+function endTurnIfOpen(session, endTimeMs, reason) {
+  if (!session.currentTurn) return;
+  const turn = session.currentTurn;
+  session.currentTurn = null;
+
+  const attrs = [
+    { key: 'openinference.span.kind', value: { stringValue: 'AGENT' } },
+    ...baseSpanAttrs(session),
+    { key: 'turn.number', value: { intValue: String(turn.turnNumber) } },
+    { key: 'turn.end_reason', value: { stringValue: reason } },
+    { key: 'prompt.length', value: { intValue: String(turn.promptLength || 0) } },
+  ];
+
+  if (turn.promptPreview) {
+    attrs.push({ key: 'input.value', value: { stringValue: turn.promptPreview } });
+  }
+  if (turn.lastAssistantMessage) {
+    attrs.push({ key: 'output.value', value: { stringValue: turn.lastAssistantMessage } });
+  }
+
+  if (turn.tokens) {
+    attrs.push({ key: 'gen_ai.usage.input_tokens', value: { intValue: String(turn.tokens.input || 0) } });
+    attrs.push({ key: 'gen_ai.usage.output_tokens', value: { intValue: String(turn.tokens.output || 0) } });
+  }
+
+  const name = turn.name || `Turn #${turn.turnNumber}`;
+  exportSpan(session, {
+    traceId: session.traceId,
+    spanId: turn.spanId,
+    parentSpanId: session.rootSpanId,
+    name,
+    kind: 'SPAN_KIND_INTERNAL',
+    startTimeUnixNano: msToNanos(turn.startTimeMs),
+    endTimeUnixNano: msToNanos(endTimeMs),
+    attributes: attrs,
+    status: spanStatusOk(),
+  });
+}
+
+function finalizeTurn(conversationId, endTimeMs, reason) {
+  const session = state.sessions.get(conversationId);
+  if (!session) return;
+  endTurnIfOpen(session, endTimeMs, reason);
+}
+
+function flushPendingLlmCalls(session) {
+  for (const call of session.pendingLlmCalls.splice(0)) {
+    if (call.timer) clearTimeout(call.timer);
+    exportSpan(session, call.span);
+  }
+}
+
+function finalizeSession(conversationId, reason) {
+  const session = state.sessions.get(conversationId);
+  if (!session) return;
+
+  if (session.timers.sessionIdle) clearTimeout(session.timers.sessionIdle);
+  if (session.timers.turnIdle) clearTimeout(session.timers.turnIdle);
+
+  // End any active turn.
+  endTurnIfOpen(session, session.lastEventTimeMs || Date.now(), `session_${reason}`);
+
+  // Export any pending LLM spans without token attachment.
+  flushPendingLlmCalls(session);
+
+  const endTimeMs = session.lastEventTimeMs || Date.now();
+
+  const attrs = [
+    { key: 'openinference.span.kind', value: { stringValue: 'CHAIN' } },
+    ...baseSpanAttrs(session),
+    { key: 'session.turn_count', value: { intValue: String(session.turnCount) } },
+    { key: 'session.api_call_count', value: { intValue: String(session.apiCallCount) } },
+    { key: 'gen_ai.usage.input_tokens', value: { intValue: String(session.tokens.input) } },
+    { key: 'gen_ai.usage.output_tokens', value: { intValue: String(session.tokens.output) } },
+    { key: 'codex.session_end_reason', value: { stringValue: reason } },
+  ];
+
+  if (session.model) attrs.push({ key: 'gen_ai.request.model', value: { stringValue: session.model } });
+  if (session.reasoningEffort) attrs.push({ key: 'codex.reasoning_effort', value: { stringValue: session.reasoningEffort } });
+  if (session.approvalPolicy) attrs.push({ key: 'codex.approval_policy', value: { stringValue: session.approvalPolicy } });
+  if (session.sandboxPolicy) attrs.push({ key: 'codex.sandbox_policy', value: { stringValue: session.sandboxPolicy } });
+  if (session.mcpServers) attrs.push({ key: 'codex.mcp_servers', value: { stringValue: session.mcpServers } });
+
+  exportSpan(session, {
+    traceId: session.traceId,
+    spanId: session.rootSpanId,
+    name: 'Codex Session',
+    kind: 'SPAN_KIND_INTERNAL',
+    startTimeUnixNano: msToNanos(session.startTimeMs),
+    endTimeUnixNano: msToNanos(endTimeMs),
+    attributes: attrs,
+    status: spanStatusOk(),
+  });
+
+  state.sessions.delete(conversationId);
+}
+
+function getOrCreateSession(conversationId, meta) {
+  const existing = state.sessions.get(conversationId);
+  if (existing) return existing;
+  const created = newSession(conversationId, meta);
+  state.sessions.set(conversationId, created);
+  return created;
+}
+
+function handleCodexLogEvent(meta, attrsObj) {
+  const eventName = attrsObj['event.name'];
+  if (!eventName || typeof eventName !== 'string') return;
+
+  const conversationId = attrsObj['conversation.id'];
+  if (!conversationId || typeof conversationId !== 'string') return;
+
+  const timestampMs = parseIsoToMs(attrsObj['event.timestamp']) || meta.timestampMs || Date.now();
+  meta.timestampMs = timestampMs;
+  meta.model = attrsObj.model || attrsObj.slug || meta.model;
+  meta.terminalType = attrsObj['terminal.type'] || meta.terminalType;
+
+  const session = getOrCreateSession(conversationId, meta);
+  session.lastEventTimeMs = timestampMs;
+  if (meta.cwd) session.cwd = meta.cwd;
+
+  // Fallback turn completion if notify isn't configured.
+  scheduleTurnIdleFallback(session);
+  scheduleSessionIdleFlush(session);
+
+  if (eventName === 'codex.conversation_starts') {
+    session.providerName = attrsObj.provider_name || session.providerName;
+    session.reasoningEffort = attrsObj.reasoning_effort || session.reasoningEffort;
+    session.approvalPolicy = attrsObj.approval_policy || session.approvalPolicy;
+    session.sandboxPolicy = attrsObj.sandbox_policy || session.sandboxPolicy;
+    session.mcpServers = attrsObj.mcp_servers || session.mcpServers;
+    session.model = attrsObj.model || attrsObj.slug || session.model;
+    logDebug('conversation_starts', conversationId, session.serviceName);
+    return;
+  }
+
+  if (eventName === 'codex.user_prompt') {
+    // Close any prior active turn (shouldn't usually happen, but keep trace consistent).
+    if (session.currentTurn) endTurnIfOpen(session, timestampMs, 'new_prompt');
+
+    session.turnCount += 1;
+    const turnNumber = session.turnCount;
+    const prompt = attrsObj.prompt || null;
+    const promptPreview = prompt ? getPreview(prompt, 400) : null;
+    const promptLength = parseDurationMs(attrsObj.prompt_length) || (prompt ? prompt.length : 0);
+
+    const turnSpanId = randomHex(8);
+    const name = promptPreview ? `Turn #${turnNumber}: ${getPreview(promptPreview, 60)}` : `Turn #${turnNumber}`;
+    session.currentTurn = {
+      spanId: turnSpanId,
+      turnNumber,
+      startTimeMs: timestampMs,
+      name,
+      promptLength,
+      promptPreview,
+      lastAssistantMessage: null,
+      tokens: { input: 0, output: 0 },
+    };
+    logDebug('user_prompt', conversationId, `turn=${turnNumber}`);
+    return;
+  }
+
+  if (eventName === 'codex.api_request') {
+    session.apiCallCount += 1;
+    session.llmRequestSeq += 1;
+
+    const duration = parseDurationMs(attrsObj.duration_ms) || 0;
+    const startTimeMs = Math.max(0, timestampMs - duration);
+    const endTimeMs = timestampMs;
+    const httpStatus = attrsObj['http.response.status_code'];
+    const attempt = attrsObj.attempt;
+    const errorMessage = attrsObj['error.message'] || null;
+
+    const model = attrsObj.model || attrsObj.slug || session.model || 'unknown';
+    const inTurn = Boolean(session.currentTurn);
+    const turnNumber = session.currentTurn ? session.currentTurn.turnNumber : 0;
+    const parentSpanId = session.currentTurn ? session.currentTurn.spanId : session.rootSpanId;
+
+    const spanId = randomHex(8);
+    const base = [
+      { key: 'openinference.span.kind', value: { stringValue: 'LLM' } },
+      ...baseSpanAttrs(session),
+      { key: 'gen_ai.operation.name', value: { stringValue: 'chat' } },
+      { key: 'gen_ai.request.model', value: { stringValue: model } },
+      { key: 'llm.latency.total_ms', value: { intValue: String(duration) } },
+      { key: 'llm.request.sequence', value: { intValue: String(session.llmRequestSeq) } },
+      { key: 'turn.number', value: { intValue: String(turnNumber) } },
+    ];
+    if (typeof httpStatus === 'number') {
+      base.push({ key: 'http.response.status_code', value: { intValue: String(httpStatus) } });
+    }
+    if (typeof attempt === 'number') {
+      base.push({ key: 'codex.request.attempt', value: { intValue: String(attempt) } });
+    }
+    if (errorMessage) {
+      base.push({ key: 'error.message', value: { stringValue: String(errorMessage) } });
+    }
+
+    const span = {
+      traceId: session.traceId,
+      spanId,
+      parentSpanId,
+      name: `LLM Call: ${model}`,
+      kind: 'SPAN_KIND_CLIENT',
+      startTimeUnixNano: msToNanos(startTimeMs),
+      endTimeUnixNano: msToNanos(endTimeMs),
+      attributes: base,
+      status: errorMessage || (typeof httpStatus === 'number' && httpStatus >= 400) ? spanStatusError(errorMessage || '') : spanStatusOk(),
+    };
+
+    const pending = { span, timer: null, inTurn, turnNumber };
+    pending.timer = setTimeout(() => {
+      // If no tokens arrive (no response.completed sse_event), export anyway.
+      exportSpan(session, span);
+    }, 10_000);
+    session.pendingLlmCalls.push(pending);
+    logDebug('api_request', conversationId, `turn=${turnNumber}`, `seq=${session.llmRequestSeq}`);
+    return;
+  }
+
+  if (eventName === 'codex.sse_event') {
+    const kind = attrsObj['event.kind'];
+    if (kind === 'response.completed') {
+      const inputTokensParsed = parseDurationMs(attrsObj.input_token_count);
+      const outputTokensParsed = parseDurationMs(attrsObj.output_token_count);
+      const cachedTokensParsed = parseDurationMs(attrsObj.cached_token_count);
+      const reasoningTokensParsed = parseDurationMs(attrsObj.reasoning_token_count);
+      const toolTokensParsed = parseDurationMs(attrsObj.tool_token_count);
+
+      // Codex can emit multiple `response.completed` events; some may omit usage.
+      // Only consume a pending api_request when token usage is actually present.
+      const hasUsage = [
+        inputTokensParsed,
+        outputTokensParsed,
+        cachedTokensParsed,
+        reasoningTokensParsed,
+        toolTokensParsed,
+      ].some((v) => v != null);
+
+      if (!hasUsage) return;
+
+      const inputTokens = inputTokensParsed || 0;
+      const outputTokens = outputTokensParsed || 0;
+      const cachedTokens = cachedTokensParsed || 0;
+      const reasoningTokens = reasoningTokensParsed || 0;
+      const toolTokens = toolTokensParsed || 0;
+
+      const pending = session.pendingLlmCalls.shift();
+      if (pending) {
+        if (pending.timer) clearTimeout(pending.timer);
+        const span = pending.span;
+        span.name = `LLM Call: ${attrGetString(span.attributes, 'gen_ai.request.model') || 'model'} (${inputTokens}→${outputTokens} tokens)`;
+
+        attrUpsert(span.attributes, 'gen_ai.usage.input_tokens', { intValue: String(inputTokens) });
+        attrUpsert(span.attributes, 'gen_ai.usage.output_tokens', { intValue: String(outputTokens) });
+        if (cachedTokensParsed != null) attrUpsert(span.attributes, 'codex.usage.cached_token_count', { intValue: String(cachedTokens) });
+        if (reasoningTokensParsed != null) attrUpsert(span.attributes, 'codex.usage.reasoning_token_count', { intValue: String(reasoningTokens) });
+        if (toolTokensParsed != null) attrUpsert(span.attributes, 'codex.usage.tool_token_count', { intValue: String(toolTokens) });
+
+        exportSpan(session, span);
+
+        // Aggregate counts at session + current turn levels.
+        session.tokens.input += inputTokens;
+        session.tokens.output += outputTokens;
+        session.tokens.cached += cachedTokens;
+        session.tokens.reasoning += reasoningTokens;
+        session.tokens.tool += toolTokens;
+
+        if (session.currentTurn) {
+          session.currentTurn.tokens.input += inputTokens;
+          session.currentTurn.tokens.output += outputTokens;
+        }
+      }
+    }
+    return;
+  }
+
+  if (eventName === 'codex.tool_decision') {
+    const callId = attrsObj.call_id;
+    const toolName = attrsObj.tool_name;
+    if (callId && toolName) {
+      const decision = attrsObj.decision || null;
+      const blocksTurnEnd = Boolean(decision) && !['denied', 'abort'].includes(String(decision));
+      session.pendingToolDecisions.set(String(callId), {
+        toolName: String(toolName),
+        decision,
+        source: attrsObj.source || null,
+        timestampMs,
+        blocksTurnEnd,
+      });
+    }
+    return;
+  }
+
+  if (eventName === 'codex.tool_result') {
+    const toolName = attrsObj.tool_name || 'tool';
+    const duration = parseDurationMs(attrsObj.duration_ms) || 0;
+    const startTimeMs = Math.max(0, timestampMs - duration);
+    const endTimeMs = timestampMs;
+    const callId = attrsObj.call_id ? String(attrsObj.call_id) : null;
+    const success = String(attrsObj.success || 'true').toLowerCase() === 'true';
+
+    const parentSpanId = session.currentTurn ? session.currentTurn.spanId : session.rootSpanId;
+    const turnNumber = session.currentTurn ? session.currentTurn.turnNumber : 0;
+
+    const spanAttrs = [
+      { key: 'openinference.span.kind', value: { stringValue: 'TOOL' } },
+      ...baseSpanAttrs(session),
+      { key: 'gen_ai.tool.name', value: { stringValue: String(toolName) } },
+      { key: 'turn.number', value: { intValue: String(turnNumber) } },
+      { key: 'tool.success', value: { boolValue: success } },
+      { key: 'tool.duration_ms', value: { intValue: String(duration) } },
+    ];
+
+    if (callId) spanAttrs.push({ key: 'tool.call_id', value: { stringValue: callId } });
+
+    const decision = callId ? session.pendingToolDecisions.get(callId) : null;
+    if (decision) {
+      if (decision.decision) spanAttrs.push({ key: 'tool.decision', value: { stringValue: String(decision.decision) } });
+      if (decision.source) spanAttrs.push({ key: 'tool.decision_source', value: { stringValue: String(decision.source) } });
+      session.pendingToolDecisions.delete(callId);
+    }
+
+    // Avoid high-volume outputs; keep only a short preview.
+    if (attrsObj.output && typeof attrsObj.output === 'string') {
+      spanAttrs.push({ key: 'tool.output_preview', value: { stringValue: getPreview(attrsObj.output, 400) } });
+      spanAttrs.push({ key: 'tool.output_length', value: { intValue: String(attrsObj.output.length) } });
+    }
+
+    exportSpan(session, {
+      traceId: session.traceId,
+      spanId: randomHex(8),
+      parentSpanId,
+      name: `Tool: ${toolName}`,
+      kind: 'SPAN_KIND_INTERNAL',
+      startTimeUnixNano: msToNanos(startTimeMs),
+      endTimeUnixNano: msToNanos(endTimeMs),
+      attributes: spanAttrs,
+      status: success ? spanStatusOk() : spanStatusError('tool_failed'),
+    });
+
+    return;
+  }
+}
+
+function handleNotify(notification) {
+  if (!notification || typeof notification !== 'object') return;
+  if (notification.type !== 'agent-turn-complete') return;
+
+  const conversationId = notification['thread-id'];
+  if (!conversationId || typeof conversationId !== 'string') return;
+
+  const session = state.sessions.get(conversationId);
+  if (!session) return;
+
+  if (notification.cwd && typeof notification.cwd === 'string') {
+    session.cwd = notification.cwd;
+  }
+
+  const msg = notification['last-assistant-message'];
+  if (session.currentTurn && typeof msg === 'string') {
+    session.currentTurn.lastAssistantMessage = getPreview(msg, 400);
+  }
+
+  finalizeTurn(conversationId, Date.now(), 'notify.agent-turn-complete');
+}
+
+// =============================================================================
+// HTTP server
+// =============================================================================
+
+async function handleLogsRequest(req, res) {
+  const raw = await readRequestBody(req);
+  const bodyBuf = maybeGunzip(raw);
+
+  let otlp;
+  try {
+    otlp = JSON.parse(bodyBuf.toString('utf8'));
+  } catch (e) {
+    logDebug('failed to parse logs json; forwarding raw only', e?.message);
+    // Forward as-is, best-effort.
+    try {
+      httpPostJson(FORWARD_LOGS_ENDPOINT, JSON.parse(bodyBuf.toString('utf8')));
+    } catch {}
+    return jsonOk(res);
+  }
+
+  const events = [];
+  const resourceLogs = Array.isArray(otlp.resourceLogs) ? otlp.resourceLogs : [];
+  for (const rl of resourceLogs) {
+    const resourceAttrs = Array.isArray(rl?.resource?.attributes) ? rl.resource.attributes : [];
+    const serviceName = attrGetString(resourceAttrs, 'service.name') || 'codex';
+    const serviceVersion = attrGetString(resourceAttrs, 'service.version') || 'unknown';
+    const env = attrGetString(resourceAttrs, 'env') || 'dev';
+
+    const scopeLogs = Array.isArray(rl?.scopeLogs) ? rl.scopeLogs : [];
+    for (const sl of scopeLogs) {
+      const logRecords = Array.isArray(sl?.logRecords) ? sl.logRecords : [];
+      for (const lr of logRecords) {
+        const attrs = Array.isArray(lr?.attributes) ? lr.attributes : [];
+        const conversationId = attrGetString(attrs, 'conversation.id');
+        if (conversationId) {
+          // Normalize join key with Claude traces: use session.id everywhere.
+          attrUpsert(attrs, 'session.id', { stringValue: conversationId });
+        }
+
+        const attrsObj = {};
+        for (const a of attrs) {
+          if (!a || typeof a.key !== 'string') continue;
+          attrsObj[a.key] = anyValueToJs(a.value);
+        }
+
+        const meta = {
+          serviceName,
+          serviceVersion,
+          env,
+          appVersion: attrsObj['app.version'] || null,
+          terminalType: attrsObj['terminal.type'] || null,
+          providerName: attrsObj.provider_name || null,
+          reasoningEffort: attrsObj.reasoning_effort || null,
+          approvalPolicy: attrsObj.approval_policy || null,
+          sandboxPolicy: attrsObj.sandbox_policy || null,
+          mcpServers: attrsObj.mcp_servers || null,
+          model: attrsObj.model || attrsObj.slug || null,
+          timestampMs: parseIsoToMs(attrsObj['event.timestamp']),
+          cwd: null,
+        };
+
+        events.push({ meta, attrsObj });
+      }
+    }
+  }
+
+  // Codex exports can batch log records; ordering within a batch is not guaranteed.
+  // Sort by `event.timestamp` so response.completed attaches to the correct api_request.
+  events.sort((a, b) => (a.meta.timestampMs || 0) - (b.meta.timestampMs || 0));
+  for (const e of events) {
+    handleCodexLogEvent(e.meta, e.attrsObj);
+  }
+
+  // Forward (mutated) logs to Alloy.
+  httpPostJson(FORWARD_LOGS_ENDPOINT, otlp, { timeoutMs: 2000 });
+  return jsonOk(res);
+}
+
+async function handleNotifyRequest(req, res) {
+  const raw = await readRequestBody(req);
+  const bodyBuf = maybeGunzip(raw);
+  let obj;
+  try {
+    obj = JSON.parse(bodyBuf.toString('utf8'));
+  } catch {
+    return jsonOk(res);
+  }
+  try {
+    handleNotify(obj);
+  } catch (e) {
+    logDebug('notify handler error', e?.message);
+  }
+  return jsonOk(res);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/v1/logs') {
+      return await handleLogsRequest(req, res);
+    }
+
+    if (req.method === 'POST' && url.pathname === '/notify') {
+      return await handleNotifyRequest(req, res);
+    }
+
+    res.statusCode = 404;
+    res.end('');
+  } catch {
+    res.statusCode = 500;
+    res.end('');
+  }
+});
+
+server.listen(LISTEN_PORT, LISTEN_HOST, () => {
+  // eslint-disable-next-line no-console
+  console.error(`[codex-otel-interceptor v${INTERCEPTOR_VERSION}] listening on http://${LISTEN_HOST}:${LISTEN_PORT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[codex-otel-interceptor] forward logs  -> ${FORWARD_LOGS_ENDPOINT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[codex-otel-interceptor] export traces -> ${TRACES_ENDPOINT}`);
+});

--- a/scripts/gemini-otel-interceptor.js
+++ b/scripts/gemini-otel-interceptor.js
@@ -1,0 +1,739 @@
+#!/usr/bin/env node
+/**
+ * gemini-otel-interceptor.js
+ *
+ * Gemini CLI emits OTLP/HTTP **JSON** payloads for logs/metrics/traces, but posts them to `/`
+ * (not to `/v1/logs`, `/v1/metrics`, `/v1/traces`). The native spans are currently low-signal
+ * (generic HTTP client spans), so we synthesize Claude/Codex-style logical traces from the
+ * structured log events:
+ *
+ * Session → Turn → LLM/Tool
+ *
+ * - Start turn: `gemini_cli.user_prompt`
+ * - LLM call: `gemini_cli.api_request` + `gemini_cli.api_response`/`gemini_cli.api_error`
+ * - Tool: `gemini_cli.tool_call`
+ * - End turn: idle debounce (no official hook available)
+ */
+
+'use strict';
+
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const zlib = require('node:zlib');
+
+// =============================================================================
+// Config
+// =============================================================================
+
+const INTERCEPTOR_VERSION = '0.1.0';
+
+const LISTEN_HOST = process.env.GEMINI_OTEL_INTERCEPTOR_HOST || '127.0.0.1';
+const LISTEN_PORT = Number.parseInt(process.env.GEMINI_OTEL_INTERCEPTOR_PORT || '4322', 10);
+
+const FORWARD_BASE =
+  process.env.GEMINI_OTEL_INTERCEPTOR_FORWARD_BASE
+  || process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+  || 'http://127.0.0.1:4318';
+
+const FORWARD_LOGS_ENDPOINT =
+  process.env.GEMINI_OTEL_INTERCEPTOR_FORWARD_LOGS_ENDPOINT
+  || `${FORWARD_BASE.replace(/\/$/, '')}/v1/logs`;
+
+const FORWARD_METRICS_ENDPOINT =
+  process.env.GEMINI_OTEL_INTERCEPTOR_FORWARD_METRICS_ENDPOINT
+  || `${FORWARD_BASE.replace(/\/$/, '')}/v1/metrics`;
+
+const TRACES_ENDPOINT =
+  process.env.GEMINI_OTEL_INTERCEPTOR_TRACES_ENDPOINT
+  || process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  || `${FORWARD_BASE.replace(/\/$/, '')}/v1/traces`;
+
+// Gemini emits low-signal auto-instrumentation HTTP spans; drop by default to reduce noise.
+const FORWARD_NATIVE_TRACES = process.env.GEMINI_OTEL_INTERCEPTOR_FORWARD_NATIVE_TRACES === '1';
+
+const SESSION_IDLE_END_MS = Number.parseInt(
+  process.env.GEMINI_OTEL_INTERCEPTOR_SESSION_IDLE_END_MS || `${10 * 60 * 1000}`,
+  10
+); // default: 10 minutes
+
+const TURN_IDLE_END_MS = Number.parseInt(
+  process.env.GEMINI_OTEL_INTERCEPTOR_TURN_IDLE_END_MS || '15000',
+  10
+); // default: 15 seconds
+
+const DEBUG = process.env.GEMINI_OTEL_INTERCEPTOR_DEBUG === '1';
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+function logDebug(...args) {
+  if (!DEBUG) return;
+  // eslint-disable-next-line no-console
+  console.error('[gemini-otel-interceptor]', ...args);
+}
+
+function msToNanos(ms) {
+  return (Math.max(0, Math.floor(ms)) * 1_000_000).toString();
+}
+
+function randomHex(bytes) {
+  return crypto.randomBytes(bytes).toString('hex');
+}
+
+function getPreview(text, maxLen = 80) {
+  if (!text || typeof text !== 'string') return '';
+  const clean = text.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLen) return clean;
+  return clean.slice(0, Math.max(0, maxLen - 3)) + '...';
+}
+
+function anyValueToJs(value) {
+  if (!value || typeof value !== 'object') return null;
+  if (Object.prototype.hasOwnProperty.call(value, 'stringValue')) return value.stringValue;
+  if (Object.prototype.hasOwnProperty.call(value, 'intValue')) {
+    const raw = value.intValue;
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    const n = Number.parseInt(String(raw), 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'doubleValue')) return Number(value.doubleValue);
+  if (Object.prototype.hasOwnProperty.call(value, 'boolValue')) return Boolean(value.boolValue);
+  return null;
+}
+
+function attrFind(attributes, key) {
+  if (!Array.isArray(attributes)) return null;
+  return attributes.find((a) => a && a.key === key) || null;
+}
+
+function attrGet(attributes, key) {
+  const a = attrFind(attributes, key);
+  return a ? anyValueToJs(a.value) : null;
+}
+
+function attrGetString(attributes, key) {
+  const a = attrFind(attributes, key);
+  if (!a || !a.value) return null;
+  if (Object.prototype.hasOwnProperty.call(a.value, 'stringValue')) return a.value.stringValue;
+  if (Object.prototype.hasOwnProperty.call(a.value, 'intValue')) return String(a.value.intValue);
+  return null;
+}
+
+function attrUpsert(attributes, key, value) {
+  if (!Array.isArray(attributes)) return;
+  const existing = attrFind(attributes, key);
+  if (existing) {
+    existing.value = value;
+    return;
+  }
+  attributes.push({ key, value });
+}
+
+function parseIsoToMs(iso) {
+  if (!iso || typeof iso !== 'string') return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function parseDurationMs(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.max(0, Math.floor(value));
+  if (typeof value === 'string') {
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) ? Math.max(0, n) : null;
+  }
+  return null;
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+function maybeGunzip(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length < 2) return buf;
+  if (buf[0] === 0x1f && buf[1] === 0x8b) {
+    try {
+      return zlib.gunzipSync(buf);
+    } catch {
+      return buf;
+    }
+  }
+  return buf;
+}
+
+function httpPostJson(urlStr, obj, { timeoutMs = 2000 } = {}) {
+  try {
+    const data = Buffer.from(JSON.stringify(obj));
+    const u = new URL(urlStr);
+    const mod = u.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      {
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'https:' ? 443 : 80),
+        path: u.pathname + (u.search || ''),
+        method: 'POST',
+        agent: false,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': data.length,
+        },
+      },
+      (res) => res.resume()
+    );
+    req.on('error', () => {});
+    req.setTimeout(timeoutMs, () => req.destroy());
+    req.end(data);
+  } catch {
+    // best-effort
+  }
+}
+
+function jsonOk(res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  // OTLP/HTTP JSON responses usually return `partialSuccess`; Gemini accepts this shape.
+  res.end('{"partialSuccess":{}}');
+}
+
+// =============================================================================
+// Trace synthesis state
+// =============================================================================
+
+const state = {
+  sessions: new Map(), // session.id -> session state
+};
+
+function newSession(sessionId, meta) {
+  return {
+    sessionId,
+    traceId: randomHex(16),
+    rootSpanId: randomHex(8),
+    startTimeMs: meta.timestampMs || Date.now(),
+    lastEventTimeMs: meta.timestampMs || Date.now(),
+    serviceName: meta.serviceName || 'gemini-cli',
+    serviceVersion: meta.serviceVersion || meta.appVersion || 'unknown',
+    env: meta.env || 'dev',
+
+    providerName: meta.providerName || 'Google',
+    model: meta.model || null,
+    approvalMode: meta.approvalMode || null,
+    sandboxEnabled: meta.sandboxEnabled ?? null,
+    mcpServers: meta.mcpServers || null,
+    cwd: meta.cwd || null,
+
+    turnCount: 0,
+    apiCallCount: 0,
+    tokens: { input: 0, output: 0, cached: 0, thoughts: 0, tool: 0, total: 0 },
+
+    currentTurn: null,
+
+    // prompt_id -> queue of pending api requests
+    pendingApiRequests: new Map(),
+
+    timers: { sessionIdle: null, turnIdle: null },
+  };
+}
+
+function getOrCreateSession(sessionId, meta) {
+  const existing = state.sessions.get(sessionId);
+  if (existing) return existing;
+  const created = newSession(sessionId, meta);
+  state.sessions.set(sessionId, created);
+  return created;
+}
+
+function scheduleSessionIdleFlush(session) {
+  if (session.timers.sessionIdle) clearTimeout(session.timers.sessionIdle);
+  session.timers.sessionIdle = setTimeout(() => {
+    finalizeSession(session.sessionId, 'idle_timeout');
+  }, SESSION_IDLE_END_MS);
+}
+
+function scheduleTurnIdleFallback(session) {
+  if (session.timers.turnIdle) clearTimeout(session.timers.turnIdle);
+  if (!session.currentTurn) return;
+  session.timers.turnIdle = setTimeout(() => {
+    finalizeTurn(session.sessionId, Date.now(), 'idle_timeout');
+  }, TURN_IDLE_END_MS);
+}
+
+function baseSpanAttrs(session) {
+  return [
+    { key: 'gen_ai.system', value: { stringValue: session.providerName || 'Google' } },
+    { key: 'gen_ai.provider.name', value: { stringValue: session.providerName || 'Google' } },
+    { key: 'gen_ai.conversation.id', value: { stringValue: session.sessionId } },
+    { key: 'conversation.id', value: { stringValue: session.sessionId } },
+    { key: 'session.id', value: { stringValue: session.sessionId } },
+  ];
+}
+
+function spanStatusOk() {
+  return { code: 'STATUS_CODE_OK' };
+}
+
+function spanStatusError(message = '') {
+  return { code: 'STATUS_CODE_ERROR', message };
+}
+
+function makeSpanRecord(session, span) {
+  const resourceAttrs = [
+    { key: 'service.name', value: { stringValue: session.serviceName || 'gemini-cli' } },
+    { key: 'service.version', value: { stringValue: session.serviceVersion || 'unknown' } },
+    { key: 'gemini.interceptor.version', value: { stringValue: INTERCEPTOR_VERSION } },
+    { key: 'host.name', value: { stringValue: os.hostname() } },
+    { key: 'os.type', value: { stringValue: os.platform() } },
+    { key: 'process.pid', value: { intValue: process.pid.toString() } },
+    { key: 'service.instance.id', value: { stringValue: os.hostname() } },
+    { key: 'env', value: { stringValue: session.env || 'dev' } },
+    { key: 'deployment.environment', value: { stringValue: session.env || 'dev' } },
+  ];
+
+  if (session.cwd) resourceAttrs.push({ key: 'working_directory', value: { stringValue: session.cwd } });
+
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: resourceAttrs },
+        scopeSpans: [
+          {
+            scope: { name: 'gemini-otel-interceptor', version: INTERCEPTOR_VERSION },
+            spans: [span],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function exportSpan(session, span) {
+  httpPostJson(TRACES_ENDPOINT, makeSpanRecord(session, span));
+}
+
+function endTurnIfOpen(session, endTimeMs, reason) {
+  if (!session.currentTurn) return;
+  const turn = session.currentTurn;
+  session.currentTurn = null;
+
+  const attrs = [
+    { key: 'openinference.span.kind', value: { stringValue: 'AGENT' } },
+    ...baseSpanAttrs(session),
+    { key: 'turn.number', value: { intValue: String(turn.turnNumber) } },
+    { key: 'turn.end_reason', value: { stringValue: reason } },
+    { key: 'prompt.length', value: { intValue: String(turn.promptLength || 0) } },
+  ];
+
+  if (turn.promptId) attrs.push({ key: 'gemini.prompt_id', value: { stringValue: String(turn.promptId) } });
+  if (turn.promptPreview) attrs.push({ key: 'input.value', value: { stringValue: turn.promptPreview } });
+  if (turn.lastAssistantMessage) attrs.push({ key: 'output.value', value: { stringValue: turn.lastAssistantMessage } });
+
+  if (turn.tokens) {
+    attrs.push({ key: 'gen_ai.usage.input_tokens', value: { intValue: String(turn.tokens.input || 0) } });
+    attrs.push({ key: 'gen_ai.usage.output_tokens', value: { intValue: String(turn.tokens.output || 0) } });
+  }
+
+  const name = turn.name || `Turn #${turn.turnNumber}`;
+  exportSpan(session, {
+    traceId: session.traceId,
+    spanId: turn.spanId,
+    parentSpanId: session.rootSpanId,
+    name,
+    kind: 'SPAN_KIND_INTERNAL',
+    startTimeUnixNano: msToNanos(turn.startTimeMs),
+    endTimeUnixNano: msToNanos(endTimeMs),
+    attributes: attrs,
+    status: spanStatusOk(),
+  });
+}
+
+function finalizeTurn(sessionId, endTimeMs, reason) {
+  const session = state.sessions.get(sessionId);
+  if (!session) return;
+  endTurnIfOpen(session, endTimeMs, reason);
+}
+
+function finalizeSession(sessionId, reason) {
+  const session = state.sessions.get(sessionId);
+  if (!session) return;
+
+  if (session.timers.sessionIdle) clearTimeout(session.timers.sessionIdle);
+  if (session.timers.turnIdle) clearTimeout(session.timers.turnIdle);
+
+  // End any active turn.
+  endTurnIfOpen(session, session.lastEventTimeMs || Date.now(), `session_${reason}`);
+
+  const endTimeMs = session.lastEventTimeMs || Date.now();
+
+  const attrs = [
+    { key: 'openinference.span.kind', value: { stringValue: 'CHAIN' } },
+    ...baseSpanAttrs(session),
+    { key: 'session.turn_count', value: { intValue: String(session.turnCount) } },
+    { key: 'session.api_call_count', value: { intValue: String(session.apiCallCount) } },
+    { key: 'gen_ai.usage.input_tokens', value: { intValue: String(session.tokens.input) } },
+    { key: 'gen_ai.usage.output_tokens', value: { intValue: String(session.tokens.output) } },
+    { key: 'gemini.session_end_reason', value: { stringValue: reason } },
+  ];
+
+  if (session.model) attrs.push({ key: 'gen_ai.request.model', value: { stringValue: session.model } });
+  if (session.approvalMode) attrs.push({ key: 'gemini.approval_mode', value: { stringValue: String(session.approvalMode) } });
+  if (session.sandboxEnabled != null) attrs.push({ key: 'gemini.sandbox_enabled', value: { boolValue: Boolean(session.sandboxEnabled) } });
+  if (session.mcpServers) attrs.push({ key: 'gemini.mcp_servers', value: { stringValue: String(session.mcpServers) } });
+
+  exportSpan(session, {
+    traceId: session.traceId,
+    spanId: session.rootSpanId,
+    name: 'Gemini Session',
+    kind: 'SPAN_KIND_INTERNAL',
+    startTimeUnixNano: msToNanos(session.startTimeMs),
+    endTimeUnixNano: msToNanos(endTimeMs),
+    attributes: attrs,
+    status: spanStatusOk(),
+  });
+
+  state.sessions.delete(sessionId);
+}
+
+function extractCwdFromRequestText(requestText) {
+  if (!requestText || typeof requestText !== 'string') return null;
+  // The CLI injects a system message containing this line.
+  const m = requestText.match(/I'm currently working in the directory:\\s*([^\\r\\n]+)/);
+  if (m && m[1]) return m[1].trim();
+  return null;
+}
+
+function handleGeminiLogEvent(meta, attrsObj) {
+  const eventName = attrsObj['event.name'];
+  if (!eventName || typeof eventName !== 'string') return;
+
+  const sessionId = attrsObj['session.id'];
+  if (!sessionId || typeof sessionId !== 'string') return;
+
+  const timestampMs = parseIsoToMs(attrsObj['event.timestamp']) || meta.timestampMs || Date.now();
+  meta.timestampMs = timestampMs;
+  meta.model = attrsObj.model || meta.model;
+
+  const session = getOrCreateSession(sessionId, meta);
+  session.lastEventTimeMs = timestampMs;
+
+  scheduleSessionIdleFlush(session);
+  scheduleTurnIdleFallback(session);
+
+  if (eventName === 'gemini_cli.config') {
+    session.model = attrsObj.model || session.model;
+    session.approvalMode = attrsObj.approval_mode || session.approvalMode;
+    if (attrsObj.sandbox_enabled != null) session.sandboxEnabled = Boolean(attrsObj.sandbox_enabled);
+    if (attrsObj.mcp_servers) session.mcpServers = String(attrsObj.mcp_servers);
+    return;
+  }
+
+  if (eventName === 'gemini_cli.user_prompt') {
+    // Close any prior active turn.
+    if (session.currentTurn) endTurnIfOpen(session, timestampMs, 'new_prompt');
+
+    session.turnCount += 1;
+    const turnNumber = session.turnCount;
+    const prompt = attrsObj.prompt || null;
+    const promptPreview = prompt ? getPreview(prompt, 400) : null;
+    const promptLength = parseDurationMs(attrsObj.prompt_length) || (prompt ? prompt.length : 0);
+    const promptId = attrsObj.prompt_id || null;
+
+    const turnSpanId = randomHex(8);
+    const name = promptPreview ? `Turn #${turnNumber}: ${getPreview(promptPreview, 60)}` : `Turn #${turnNumber}`;
+    session.currentTurn = {
+      spanId: turnSpanId,
+      turnNumber,
+      startTimeMs: timestampMs,
+      name,
+      promptLength,
+      promptPreview,
+      promptId,
+      lastAssistantMessage: null,
+      tokens: { input: 0, output: 0 },
+    };
+    return;
+  }
+
+  if (eventName === 'gemini_cli.api_request') {
+    session.apiCallCount += 1;
+
+    const promptId = attrsObj.prompt_id ? String(attrsObj.prompt_id) : null;
+    const model = attrsObj.model || session.model || 'unknown';
+    const requestText = attrsObj.request_text || null;
+
+    const cwd = extractCwdFromRequestText(requestText);
+    if (cwd) session.cwd = cwd;
+
+    if (promptId) {
+      const q = session.pendingApiRequests.get(promptId) || [];
+      q.push({
+        timestampMs,
+        model,
+        requestTextPreview: requestText ? getPreview(requestText, 400) : null,
+        requestTextLength: requestText && typeof requestText === 'string' ? requestText.length : 0,
+      });
+      session.pendingApiRequests.set(promptId, q);
+    }
+    return;
+  }
+
+  if (eventName === 'gemini_cli.api_response' || eventName === 'gemini_cli.api_error') {
+    const promptId = attrsObj.prompt_id ? String(attrsObj.prompt_id) : null;
+    const model = attrsObj.model || session.model || 'unknown';
+
+    const statusCode = attrsObj.status_code;
+    const duration = parseDurationMs(attrsObj.duration_ms ?? attrsObj.latency_ms) || 0;
+    const startTimeMs = Math.max(0, timestampMs - duration);
+    const endTimeMs = timestampMs;
+
+    const inputTokens = parseDurationMs(attrsObj.input_token_count) || 0;
+    const outputTokens = parseDurationMs(attrsObj.output_token_count) || 0;
+    const cachedTokens = parseDurationMs(attrsObj.cached_content_token_count) || 0;
+    const thoughtsTokens = parseDurationMs(attrsObj.thoughts_token_count) || 0;
+    const toolTokens = parseDurationMs(attrsObj.tool_token_count) || 0;
+    const totalTokens = parseDurationMs(attrsObj.total_token_count) || (inputTokens + outputTokens);
+
+    // Attach a short response preview to the current turn.
+    if (session.currentTurn && typeof attrsObj.response_text === 'string') {
+      session.currentTurn.lastAssistantMessage = getPreview(attrsObj.response_text, 400);
+    }
+
+    const pending = promptId ? (session.pendingApiRequests.get(promptId) || []).shift() : null;
+    if (promptId && pending) {
+      const q = session.pendingApiRequests.get(promptId) || [];
+      if (q.length === 0) session.pendingApiRequests.delete(promptId);
+      else session.pendingApiRequests.set(promptId, q);
+    }
+
+    const inTurn = Boolean(session.currentTurn);
+    const turnNumber = session.currentTurn ? session.currentTurn.turnNumber : 0;
+    const parentSpanId = session.currentTurn ? session.currentTurn.spanId : session.rootSpanId;
+
+    const spanAttrs = [
+      { key: 'openinference.span.kind', value: { stringValue: 'LLM' } },
+      ...baseSpanAttrs(session),
+      { key: 'gen_ai.operation.name', value: { stringValue: 'chat' } },
+      { key: 'gen_ai.request.model', value: { stringValue: model } },
+      { key: 'llm.latency.total_ms', value: { intValue: String(duration) } },
+      { key: 'turn.number', value: { intValue: String(turnNumber) } },
+    ];
+
+    if (promptId) spanAttrs.push({ key: 'gemini.prompt_id', value: { stringValue: promptId } });
+    if (typeof statusCode === 'number') spanAttrs.push({ key: 'http.response.status_code', value: { intValue: String(statusCode) } });
+
+    if (pending?.requestTextPreview) spanAttrs.push({ key: 'llm.request_text_preview', value: { stringValue: pending.requestTextPreview } });
+    if (pending?.requestTextLength) spanAttrs.push({ key: 'llm.request_text_length', value: { intValue: String(pending.requestTextLength) } });
+
+    // Usage (Gemini naming differs slightly; normalize to GenAI conventions + keep raw fields).
+    spanAttrs.push({ key: 'gen_ai.usage.input_tokens', value: { intValue: String(inputTokens) } });
+    spanAttrs.push({ key: 'gen_ai.usage.output_tokens', value: { intValue: String(outputTokens) } });
+    spanAttrs.push({ key: 'gemini.usage.cached_content_token_count', value: { intValue: String(cachedTokens) } });
+    spanAttrs.push({ key: 'gemini.usage.thoughts_token_count', value: { intValue: String(thoughtsTokens) } });
+    spanAttrs.push({ key: 'gemini.usage.tool_token_count', value: { intValue: String(toolTokens) } });
+    spanAttrs.push({ key: 'gemini.usage.total_token_count', value: { intValue: String(totalTokens) } });
+
+    const isError = eventName === 'gemini_cli.api_error' || (typeof statusCode === 'number' && statusCode >= 400);
+    const errMsg = typeof attrsObj.error === 'string' ? attrsObj.error : '';
+
+    exportSpan(session, {
+      traceId: session.traceId,
+      spanId: randomHex(8),
+      parentSpanId,
+      name: `LLM Call: ${model} (${inputTokens}→${outputTokens} tokens)`,
+      kind: 'SPAN_KIND_CLIENT',
+      startTimeUnixNano: msToNanos(startTimeMs),
+      endTimeUnixNano: msToNanos(endTimeMs),
+      attributes: spanAttrs,
+      status: isError ? spanStatusError(errMsg) : spanStatusOk(),
+    });
+
+    // Aggregate counts at session + current turn levels.
+    session.tokens.input += inputTokens;
+    session.tokens.output += outputTokens;
+    session.tokens.cached += cachedTokens;
+    session.tokens.thoughts += thoughtsTokens;
+    session.tokens.tool += toolTokens;
+    session.tokens.total += totalTokens;
+
+    if (session.currentTurn) {
+      session.currentTurn.tokens.input += inputTokens;
+      session.currentTurn.tokens.output += outputTokens;
+    }
+
+    // For one-shot mode, end the turn promptly once we have a response.
+    // (We still keep the idle fallback as a safety net for tool loops.)
+    if (!inTurn) return;
+    scheduleTurnIdleFallback(session);
+    return;
+  }
+
+  if (eventName === 'gemini_cli.tool_call') {
+    const fn = attrsObj.function_name || attrsObj.tool_name || 'tool';
+    const duration = parseDurationMs(attrsObj.duration_ms) || 0;
+    const startTimeMs = Math.max(0, timestampMs - duration);
+    const endTimeMs = timestampMs;
+    const status = attrsObj.status || null;
+    const decision = attrsObj.decision || null;
+
+    const parentSpanId = session.currentTurn ? session.currentTurn.spanId : session.rootSpanId;
+    const turnNumber = session.currentTurn ? session.currentTurn.turnNumber : 0;
+
+    const spanAttrs = [
+      { key: 'openinference.span.kind', value: { stringValue: 'TOOL' } },
+      ...baseSpanAttrs(session),
+      { key: 'gen_ai.tool.name', value: { stringValue: String(fn) } },
+      { key: 'turn.number', value: { intValue: String(turnNumber) } },
+      { key: 'tool.duration_ms', value: { intValue: String(duration) } },
+    ];
+
+    if (status) spanAttrs.push({ key: 'tool.status', value: { stringValue: String(status) } });
+    if (decision) spanAttrs.push({ key: 'tool.decision', value: { stringValue: String(decision) } });
+
+    if (attrsObj.error_type) spanAttrs.push({ key: 'tool.error_type', value: { stringValue: String(attrsObj.error_type) } });
+    if (attrsObj.error && typeof attrsObj.error === 'string') spanAttrs.push({ key: 'tool.error', value: { stringValue: getPreview(attrsObj.error, 400) } });
+
+    // Avoid high-volume args; keep only a preview.
+    if (attrsObj.function_args && typeof attrsObj.function_args === 'string') {
+      spanAttrs.push({ key: 'tool.args_preview', value: { stringValue: getPreview(attrsObj.function_args, 400) } });
+      spanAttrs.push({ key: 'tool.args_length', value: { intValue: String(attrsObj.function_args.length) } });
+    }
+
+    const success = String(status || '').toLowerCase() === 'success';
+
+    exportSpan(session, {
+      traceId: session.traceId,
+      spanId: randomHex(8),
+      parentSpanId,
+      name: `Tool: ${fn}`,
+      kind: 'SPAN_KIND_INTERNAL',
+      startTimeUnixNano: msToNanos(startTimeMs),
+      endTimeUnixNano: msToNanos(endTimeMs),
+      attributes: spanAttrs,
+      status: success ? spanStatusOk() : spanStatusError(String(attrsObj.error || '')),
+    });
+
+    return;
+  }
+}
+
+// =============================================================================
+// HTTP server
+// =============================================================================
+
+async function handleGeminiOtlpEnvelope(req, res) {
+  const raw = await readRequestBody(req);
+  const bodyBuf = maybeGunzip(raw);
+
+  let otlp;
+  try {
+    otlp = JSON.parse(bodyBuf.toString('utf8'));
+  } catch (e) {
+    logDebug('failed to parse json', e?.message);
+    return jsonOk(res);
+  }
+
+  if (otlp && typeof otlp === 'object' && Array.isArray(otlp.resourceLogs)) {
+    // Mutate logs for correlation (optional but useful): copy session.id -> conversation.id.
+    const events = [];
+    for (const rl of otlp.resourceLogs) {
+      const resourceAttrs = Array.isArray(rl?.resource?.attributes) ? rl.resource.attributes : [];
+      const serviceName = attrGetString(resourceAttrs, 'service.name') || 'gemini-cli';
+      const serviceVersion = attrGetString(resourceAttrs, 'service.version') || 'unknown';
+      const env = attrGetString(resourceAttrs, 'env') || 'dev';
+
+      const scopeLogs = Array.isArray(rl?.scopeLogs) ? rl.scopeLogs : [];
+      for (const sl of scopeLogs) {
+        const logRecords = Array.isArray(sl?.logRecords) ? sl.logRecords : [];
+        for (const lr of logRecords) {
+          const attrs = Array.isArray(lr?.attributes) ? lr.attributes : [];
+
+          const sid = attrGetString(attrs, 'session.id');
+          if (sid) {
+            attrUpsert(attrs, 'conversation.id', { stringValue: sid });
+            attrUpsert(attrs, 'gen_ai.conversation.id', { stringValue: sid });
+          }
+
+          const attrsObj = {};
+          for (const a of attrs) {
+            if (!a || typeof a.key !== 'string') continue;
+            attrsObj[a.key] = anyValueToJs(a.value);
+          }
+
+          const meta = {
+            serviceName,
+            serviceVersion,
+            env,
+            model: attrsObj.model || null,
+            timestampMs: parseIsoToMs(attrsObj['event.timestamp']),
+            providerName: 'Google',
+          };
+
+          events.push({ meta, attrsObj });
+        }
+      }
+    }
+
+    // Ordering within a batch isn't guaranteed; sort by `event.timestamp`.
+    events.sort((a, b) => (a.meta.timestampMs || 0) - (b.meta.timestampMs || 0));
+    for (const e of events) handleGeminiLogEvent(e.meta, e.attrsObj);
+
+    httpPostJson(FORWARD_LOGS_ENDPOINT, otlp, { timeoutMs: 2000 });
+    return jsonOk(res);
+  }
+
+  if (otlp && typeof otlp === 'object' && Array.isArray(otlp.resourceMetrics)) {
+    httpPostJson(FORWARD_METRICS_ENDPOINT, otlp, { timeoutMs: 2000 });
+    return jsonOk(res);
+  }
+
+  if (otlp && typeof otlp === 'object' && Array.isArray(otlp.resourceSpans)) {
+    if (FORWARD_NATIVE_TRACES) httpPostJson(TRACES_ENDPOINT, otlp, { timeoutMs: 2000 });
+    return jsonOk(res);
+  }
+
+  return jsonOk(res);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    if (req.method === 'POST') {
+      // Gemini posts OTLP envelopes to `/`.
+      return await handleGeminiOtlpEnvelope(req, res);
+    }
+
+    res.statusCode = 404;
+    res.end('');
+  } catch {
+    res.statusCode = 500;
+    res.end('');
+  }
+});
+
+server.listen(LISTEN_PORT, LISTEN_HOST, () => {
+  // eslint-disable-next-line no-console
+  console.error(`[gemini-otel-interceptor v${INTERCEPTOR_VERSION}] listening on http://${LISTEN_HOST}:${LISTEN_PORT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[gemini-otel-interceptor] forward logs    -> ${FORWARD_LOGS_ENDPOINT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[gemini-otel-interceptor] forward metrics -> ${FORWARD_METRICS_ENDPOINT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[gemini-otel-interceptor] export traces   -> ${TRACES_ENDPOINT}`);
+  // eslint-disable-next-line no-console
+  console.error(`[gemini-otel-interceptor] forward native traces = ${FORWARD_NATIVE_TRACES ? 'on' : 'off'}`);
+});
+


### PR DESCRIPTION
This adds Claude-like logical tracing for Codex CLI and Gemini CLI.

- Codex: route OTLP logs through a local interceptor that forwards to the collector and synthesizes Session→Turn→LLM/Tool spans; uses Codex notify hook for accurate turn boundaries.
- Gemini: route OTLP/HTTP JSON envelopes (POST /) through a local interceptor that forwards logs/metrics to the collector and synthesizes Session→Turn→LLM/Tool spans from gemini_cli.* events.
- Collector: fix remote OTLP exporter TLS config to rely on system trust store (Tailscale Serve/Let's Encrypt).

Docs: codex-config.md, gemini-config.md, and docs/AI_TRACING_GRAFANA.md updated.