### PR TITLE
feat(tracing): Langfuse-compatible AI CLI telemetry (Feature 132)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,8 @@ journalctl --user -u i3-project-event-listener -f
 - N/A (in-memory session state, file-based telemetry export) (125-tracing-parity-codex)
 - Python 3.11+ (otel-ai-monitor), Nix (configuration), Alloy config language + Grafana Alloy 1.x, opentelemetry-proto, aiohttp, Pydantic (125-tracing-parity-codex)
 - N/A (in-memory session state in otel-ai-monitor) (125-tracing-parity-codex)
+- Python 3.11+ (otel-ai-monitor), JavaScript/Node.js (interceptors) + opentelemetry-proto, aiohttp, Grafana Alloy, existing interceptor scripts (132-langfuse-compatibility)
+- N/A (in-memory session state, remote Langfuse storage) (132-langfuse-compatibility)
 
 ## Recent Changes
 - 117-improve-notification-progress-indicators: Added Bash (hooks), Python 3.11+ (daemon/backend), Nix (configuration) + i3ipc.aio, Pydantic, eww (GTK3 widgets), swaync, inotify-tools

--- a/configurations/hetzner.nix
+++ b/configurations/hetzner.nix
@@ -194,6 +194,33 @@
       "otel-ai-monitor.service"
       "i3pm-daemon.service"
     ];
+
+    # Feature 132: Langfuse AI Observability
+    # Export traces to Langfuse for specialized LLM tracing and analytics
+    langfuse = {
+      enable = true;
+      endpoint = "https://cloud.langfuse.com/api/public/otel";
+
+      # Credential source options:
+      # - "env": Use LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY environment variables
+      # - "files": Use publicKeyFile and secretKeyFile paths (sops-nix, agenix)
+      # - "1password": Use 1Password CLI to fetch keys
+      # - "azure": Use Azure Key Vault to fetch keys
+      credentialSource = "1password";  # Use 1Password for local dev
+
+      # Azure Key Vault configuration (when credentialSource = "azure")
+      # Secrets expected: LANGFUSE-PUBLIC-KEY, LANGFUSE-SECRET-KEY
+      # azureKeyVaultName = "your-keyvault-name";
+
+      # 1Password configuration (when credentialSource = "1password")
+      onePasswordRefs = {
+        publicKey = "op://CLI/Langfuse/public_key";
+        secretKey = "op://CLI/Langfuse/secret_key";
+      };
+
+      batchTimeout = "10s";
+      batchSize = 100;
+    };
   };
 
   # Feature 123 (legacy): Disable otel-ai-collector since Alloy replaces it

--- a/configurations/thinkpad.nix
+++ b/configurations/thinkpad.nix
@@ -141,6 +141,23 @@ in
       "otel-ai-monitor.service"
       "i3pm-daemon.service"
     ];
+
+    # Feature 132: Langfuse AI Observability
+    # Export traces to Langfuse for specialized LLM tracing and analytics
+    langfuse = {
+      enable = true;
+      # Self-hosted Langfuse via Tailscale (matches Azure Key Vault credentials)
+      endpoint = "https://langfuse-thinkpad.tail286401.ts.net/api/public/otel";
+      credentialSource = "1password";  # Use 1Password for local dev
+      onePasswordRefs = {
+        publicKey = "op://CLI/Langfuse/public_key";
+        secretKey = "op://CLI/Langfuse/secret_key";
+      };
+      # Fallback: environment file for system services (1Password not available)
+      environmentFile = "/etc/langfuse/credentials";
+      batchTimeout = "10s";
+      batchSize = 100;
+    };
   };
 
   # Feature 123 (legacy): Disable otel-ai-collector - replaced by grafana-alloy

--- a/home-modules/ai-assistants/claude-code.nix
+++ b/home-modules/ai-assistants/claude-code.nix
@@ -54,6 +54,10 @@ lib.mkIf enableClaudeCode {
   # These MUST be session variables (not just settings.env) because the OTEL SDK
   # initializes when Claude Code starts, before it reads settings.json.
   # settings.env only affects subprocesses, not Claude Code itself.
+  #
+  # Feature 132: Langfuse integration environment variables
+  # LANGFUSE_* variables are optional - if set, traces will include Langfuse-specific
+  # attributes for proper observation mapping in Langfuse UI.
   home.sessionVariables = {
     CLAUDE_CODE_ENABLE_TELEMETRY = "1";
     OTEL_LOGS_EXPORTER = "otlp";
@@ -68,6 +72,14 @@ lib.mkIf enableClaudeCode {
     OTEL_LOG_USER_PROMPTS = "1";
     # Delta temporality for better memory efficiency with session metrics
     OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "delta";
+
+    # Feature 132: Langfuse integration
+    # These variables are used by the interceptor to add Langfuse-specific attributes
+    # LANGFUSE_ENABLED - Set to "1" to enable Langfuse-specific attribute emission
+    # LANGFUSE_USER_ID - Optional user identifier for Langfuse traces
+    # LANGFUSE_SESSION_ID - Optional override for session grouping (defaults to Claude session.id)
+    # LANGFUSE_TAGS - Optional JSON array of tags, e.g., '["production", "my-feature"]'
+    LANGFUSE_ENABLED = "1";
   };
 
   # Chromium is installed via programs.chromium in tools/chromium.nix

--- a/home-modules/ai-assistants/codex.nix
+++ b/home-modules/ai-assistants/codex.nix
@@ -242,6 +242,7 @@ EOF
         "CODEX_OTEL_INTERCEPTOR_HOST=${codexOtelInterceptorHost}"
         "CODEX_OTEL_INTERCEPTOR_PORT=${toString codexOtelInterceptorPort}"
         "CODEX_OTEL_INTERCEPTOR_FORWARD_BASE=http://127.0.0.1:4318"
+        "LANGFUSE_ENABLED=1"
       ];
 
       StandardOutput = "journal";

--- a/home-modules/ai-assistants/gemini-cli.nix
+++ b/home-modules/ai-assistants/gemini-cli.nix
@@ -224,6 +224,7 @@ EOF
         "GEMINI_OTEL_INTERCEPTOR_HOST=127.0.0.1"
         "GEMINI_OTEL_INTERCEPTOR_PORT=4322"
         "GEMINI_OTEL_INTERCEPTOR_FORWARD_BASE=http://127.0.0.1:4318"
+        "LANGFUSE_ENABLED=1"
       ];
 
       StandardOutput = "journal";

--- a/scripts/langfuse-auth.sh
+++ b/scripts/langfuse-auth.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# langfuse-auth.sh - Generate Langfuse OTEL authentication header
+#
+# Feature 132: Langfuse-Compatible AI CLI Tracing
+#
+# This script generates the base64-encoded authorization header required
+# for Langfuse's OTEL HTTP endpoint. The header format is:
+#   Authorization: Basic <base64(public_key:secret_key)>
+#
+# Usage:
+#   langfuse-auth.sh                    # Interactive (prompts for keys)
+#   langfuse-auth.sh --from-env         # Use LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY
+#   langfuse-auth.sh --from-1password   # Use 1Password CLI to fetch keys
+#   langfuse-auth.sh --from-azure       # Use Azure Key Vault to fetch keys
+#   langfuse-auth.sh <public_key> <secret_key>  # Direct arguments
+#
+# Output:
+#   Prints the Authorization header value to stdout
+#   (e.g., "Basic cGstbGYteHh4OnNrLWxmLXl5eQ==")
+#
+# Environment Variables (when using --from-env):
+#   LANGFUSE_PUBLIC_KEY  - Langfuse public key (pk-lf-...)
+#   LANGFUSE_SECRET_KEY  - Langfuse secret key (sk-lf-...)
+#
+# 1Password Configuration (when using --from-1password):
+#   Uses 1Password CLI (op) to fetch keys from the vault.
+#   Default references:
+#     - LANGFUSE_1P_PUBLIC_KEY_REF: "op://Development/Langfuse/public_key"
+#     - LANGFUSE_1P_SECRET_KEY_REF: "op://Development/Langfuse/secret_key"
+#
+# Azure Key Vault Configuration (when using --from-azure):
+#   Uses Azure CLI (az) to fetch keys from Key Vault.
+#   Requires:
+#     - AZURE_KEYVAULT_NAME: Name of the Azure Key Vault
+#   Optional (defaults to standard secret names):
+#     - LANGFUSE_AZ_PUBLIC_KEY_NAME: Secret name for public key (default: "LANGFUSE-PUBLIC-KEY")
+#     - LANGFUSE_AZ_SECRET_KEY_NAME: Secret name for secret key (default: "LANGFUSE-SECRET-KEY")
+
+set -euo pipefail
+
+# Default 1Password references (can be overridden via environment)
+LANGFUSE_1P_PUBLIC_KEY_REF="${LANGFUSE_1P_PUBLIC_KEY_REF:-op://Development/Langfuse/public_key}"
+LANGFUSE_1P_SECRET_KEY_REF="${LANGFUSE_1P_SECRET_KEY_REF:-op://Development/Langfuse/secret_key}"
+
+# Default Azure Key Vault secret names (matching user's existing secrets)
+LANGFUSE_AZ_PUBLIC_KEY_NAME="${LANGFUSE_AZ_PUBLIC_KEY_NAME:-LANGFUSE-PUBLIC-KEY}"
+LANGFUSE_AZ_SECRET_KEY_NAME="${LANGFUSE_AZ_SECRET_KEY_NAME:-LANGFUSE-SECRET-KEY}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [public_key] [secret_key]
+
+Generate Langfuse OTEL authentication header.
+
+Options:
+  --from-env         Use LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY environment variables
+  --from-1password   Fetch keys from 1Password vault
+  --from-azure       Fetch keys from Azure Key Vault (requires AZURE_KEYVAULT_NAME)
+  --export           Output as 'export LANGFUSE_AUTH_HEADER=...' for sourcing
+  --validate         Validate the generated header by making a test request
+  -h, --help         Show this help message
+
+Arguments:
+  public_key         Langfuse public key (pk-lf-...)
+  secret_key         Langfuse secret key (sk-lf-...)
+
+Environment Variables:
+  LANGFUSE_PUBLIC_KEY        Public key (for --from-env)
+  LANGFUSE_SECRET_KEY        Secret key (for --from-env)
+  AZURE_KEYVAULT_NAME        Azure Key Vault name (for --from-azure)
+  LANGFUSE_AZ_PUBLIC_KEY_NAME  Azure secret name for public key (default: LANGFUSE-PUBLIC-KEY)
+  LANGFUSE_AZ_SECRET_KEY_NAME  Azure secret name for secret key (default: LANGFUSE-SECRET-KEY)
+
+Examples:
+  $(basename "$0") pk-lf-xxx sk-lf-yyy
+  $(basename "$0") --from-env
+  $(basename "$0") --from-1password --export
+  $(basename "$0") --from-azure --validate
+  AZURE_KEYVAULT_NAME=my-vault $(basename "$0") --from-azure --export
+  eval "\$($(basename "$0") --from-1password --export)"
+EOF
+    exit 0
+}
+
+generate_auth_header() {
+    local public_key="$1"
+    local secret_key="$2"
+
+    # Validate key formats
+    if [[ ! "$public_key" =~ ^pk-lf- ]]; then
+        echo "Error: Invalid public key format. Expected pk-lf-..." >&2
+        exit 1
+    fi
+
+    if [[ ! "$secret_key" =~ ^sk-lf- ]]; then
+        echo "Error: Invalid secret key format. Expected sk-lf-..." >&2
+        exit 1
+    fi
+
+    # Generate base64-encoded credentials
+    local credentials="${public_key}:${secret_key}"
+    local encoded
+    encoded=$(echo -n "$credentials" | base64 -w0)
+
+    echo "Basic ${encoded}"
+}
+
+validate_header() {
+    local header="$1"
+    local endpoint="${LANGFUSE_ENDPOINT:-https://cloud.langfuse.com/api/public/otel}"
+
+    echo "Validating header against ${endpoint}..." >&2
+
+    # Make a test request (should return 200 or 400 for invalid payload, not 401)
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "${endpoint}/v1/traces" \
+        -H "Authorization: ${header}" \
+        -H "Content-Type: application/x-protobuf" \
+        --data-binary "" \
+        --max-time 10) || {
+        echo "Warning: Could not reach Langfuse endpoint" >&2
+        return 1
+    }
+
+    case "$status" in
+        200|400)
+            echo "Validation successful (status: ${status})" >&2
+            return 0
+            ;;
+        401|403)
+            echo "Error: Authentication failed (status: ${status})" >&2
+            return 1
+            ;;
+        *)
+            echo "Warning: Unexpected status code: ${status}" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Parse options
+FROM_ENV=false
+FROM_1PASSWORD=false
+FROM_AZURE=false
+EXPORT_FORMAT=false
+VALIDATE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --from-env)
+            FROM_ENV=true
+            shift
+            ;;
+        --from-1password)
+            FROM_1PASSWORD=true
+            shift
+            ;;
+        --from-azure)
+            FROM_AZURE=true
+            shift
+            ;;
+        --export)
+            EXPORT_FORMAT=true
+            shift
+            ;;
+        --validate)
+            VALIDATE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Get credentials based on source
+if [[ "$FROM_1PASSWORD" == true ]]; then
+    # Fetch from 1Password
+    if ! command -v op &> /dev/null; then
+        echo "Error: 1Password CLI (op) not found. Install it or use --from-env" >&2
+        exit 1
+    fi
+
+    echo "Fetching keys from 1Password..." >&2
+    PUBLIC_KEY=$(op read "$LANGFUSE_1P_PUBLIC_KEY_REF")
+    SECRET_KEY=$(op read "$LANGFUSE_1P_SECRET_KEY_REF")
+
+elif [[ "$FROM_AZURE" == true ]]; then
+    # Fetch from Azure Key Vault
+    if ! command -v az &> /dev/null; then
+        echo "Error: Azure CLI (az) not found. Install it or use --from-env" >&2
+        exit 1
+    fi
+
+    if [[ -z "${AZURE_KEYVAULT_NAME:-}" ]]; then
+        echo "Error: AZURE_KEYVAULT_NAME environment variable must be set" >&2
+        exit 1
+    fi
+
+    echo "Fetching keys from Azure Key Vault '${AZURE_KEYVAULT_NAME}'..." >&2
+
+    # Check if logged in to Azure
+    if ! az account show &> /dev/null; then
+        echo "Error: Not logged in to Azure. Run 'az login' first." >&2
+        exit 1
+    fi
+
+    PUBLIC_KEY=$(az keyvault secret show \
+        --vault-name "$AZURE_KEYVAULT_NAME" \
+        --name "$LANGFUSE_AZ_PUBLIC_KEY_NAME" \
+        --query "value" -o tsv)
+
+    SECRET_KEY=$(az keyvault secret show \
+        --vault-name "$AZURE_KEYVAULT_NAME" \
+        --name "$LANGFUSE_AZ_SECRET_KEY_NAME" \
+        --query "value" -o tsv)
+
+    if [[ -z "$PUBLIC_KEY" ]] || [[ -z "$SECRET_KEY" ]]; then
+        echo "Error: Failed to fetch keys from Azure Key Vault" >&2
+        exit 1
+    fi
+
+elif [[ "$FROM_ENV" == true ]]; then
+    # Use environment variables
+    if [[ -z "${LANGFUSE_PUBLIC_KEY:-}" ]] || [[ -z "${LANGFUSE_SECRET_KEY:-}" ]]; then
+        echo "Error: LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be set" >&2
+        exit 1
+    fi
+    PUBLIC_KEY="$LANGFUSE_PUBLIC_KEY"
+    SECRET_KEY="$LANGFUSE_SECRET_KEY"
+
+elif [[ $# -ge 2 ]]; then
+    # Use command line arguments
+    PUBLIC_KEY="$1"
+    SECRET_KEY="$2"
+
+else
+    # Interactive mode
+    echo "Enter Langfuse public key (pk-lf-...):" >&2
+    read -r PUBLIC_KEY
+    echo "Enter Langfuse secret key (sk-lf-...):" >&2
+    read -rs SECRET_KEY
+    echo >&2
+fi
+
+# Generate the header
+AUTH_HEADER=$(generate_auth_header "$PUBLIC_KEY" "$SECRET_KEY")
+
+# Validate if requested
+if [[ "$VALIDATE" == true ]]; then
+    if ! validate_header "$AUTH_HEADER"; then
+        exit 1
+    fi
+fi
+
+# Output in requested format
+if [[ "$EXPORT_FORMAT" == true ]]; then
+    echo "export LANGFUSE_AUTH_HEADER=\"${AUTH_HEADER}\""
+else
+    echo "$AUTH_HEADER"
+fi

--- a/specs/132-langfuse-compatibility/checklists/requirements.md
+++ b/specs/132-langfuse-compatibility/checklists/requirements.md
@@ -1,0 +1,57 @@
+# Specification Quality Checklist: Langfuse-Compatible AI CLI Tracing
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-22
+**Revised**: 2025-12-22 (incorporated LangSmith SDK patterns)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+- [x] Prior art (LangSmith SDK patterns) documented for implementation guidance
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+- [x] Prior art patterns are reference-only (not prescriptive implementation)
+
+## LangSmith Pattern Alignment
+
+- [x] Trace hierarchy pattern documented (chain → llm → tool)
+- [x] Tool call correlation pattern documented (tool_use_id)
+- [x] Content serialization pattern documented (flatten_content_blocks)
+- [x] Usage extraction pattern documented (extract_usage_metadata, sum_anthropic_tokens)
+- [x] OTEL export pattern documented (OtelSpanProcessor)
+- [x] Subagent handling pattern documented (nested chains for Task tool)
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Key dependencies noted:
+  - Langfuse endpoint access
+  - API credentials configuration
+  - Grafana Alloy extension for dual export
+- LangSmith SDK code provides implementation reference for:
+  - `_client.py`: TracedClaudeSDKClient, TurnLifecycle patterns
+  - `_hooks.py`: PreToolUse/PostToolUse hook patterns
+  - `_messages.py`: flatten_content_blocks, build_llm_input
+  - `_usage.py`: extract_usage_metadata, sum_anthropic_tokens
+  - `otel/processor.py`: OtelExporter, OtelSpanProcessor

--- a/specs/132-langfuse-compatibility/contracts/langfuse-otel-mapping.md
+++ b/specs/132-langfuse-compatibility/contracts/langfuse-otel-mapping.md
@@ -1,0 +1,326 @@
+# Contract: Langfuse OTEL Attribute Mapping
+
+**Feature**: 132-langfuse-compatibility
+**Date**: 2025-12-22
+**Version**: 1.0.0
+
+## Overview
+
+This contract defines the mapping between OTEL span attributes emitted by AI CLI interceptors and the Langfuse data model. All interceptors MUST emit attributes conforming to this contract for proper Langfuse UI rendering.
+
+---
+
+## Attribute Namespaces
+
+### Priority Order (Langfuse Processing)
+
+1. `langfuse.*` - Highest priority, direct Langfuse mapping
+2. `gen_ai.*` - OpenTelemetry GenAI semantic conventions
+3. `openinference.*` - OpenInference/Phoenix conventions
+4. Standard OTEL - Fallback (span name, status, etc.)
+
+---
+
+## Trace-Level Attributes
+
+Set on the root span of each session/conversation.
+
+| Attribute | Type | Required | Example | Maps To |
+|-----------|------|----------|---------|---------|
+| `langfuse.user.id` | string | No | `"vpittamp"` | trace.userId |
+| `langfuse.session.id` | string | No | `"i3pm-project-123"` | trace.sessionId |
+| `langfuse.trace.tags` | string (JSON) | No | `'["claude-code","nixos"]'` | trace.tags |
+| `langfuse.trace.metadata` | string (JSON) | No | `'{"branch":"main"}'` | trace.metadata |
+| `service.name` | string | Yes | `"claude-code"` | Inferred provider |
+| `service.version` | string | No | `"1.0.0"` | trace.release |
+
+### Example Root Span
+
+```
+span_name: "claude.conversation"
+attributes:
+  langfuse.user.id: "vpittamp"
+  langfuse.session.id: "project-nixos-config"
+  langfuse.trace.tags: '["claude-code", "feature-132"]'
+  service.name: "claude-code"
+  service.version: "1.0.115"
+  openinference.span.kind: "CHAIN"
+```
+
+---
+
+## Generation Observation Attributes
+
+Set on LLM/assistant turn spans.
+
+| Attribute | Type | Required | Example | Maps To |
+|-----------|------|----------|---------|---------|
+| `langfuse.observation.type` | string | Yes | `"generation"` | observation.type |
+| `langfuse.observation.name` | string | No | `"claude.assistant.turn"` | observation.name |
+| `gen_ai.request.model` | string | Yes | `"claude-opus-4-5-20251101"` | observation.model |
+| `gen_ai.system` | string | No | `"anthropic"` | metadata.ls_provider |
+| `gen_ai.prompt_json` | string (JSON) | No | `'[{"role":"user",...}]'` | observation.input |
+| `gen_ai.completion_json` | string (JSON) | No | `'{"role":"assistant",...}'` | observation.output |
+| `gen_ai.usage.input_tokens` | int | Yes | `1500` | usage.input_tokens |
+| `gen_ai.usage.output_tokens` | int | Yes | `500` | usage.output_tokens |
+| `gen_ai.usage.cost` | float | No | `0.045` | usage.total_cost |
+| `langfuse.observation.usage_details` | string (JSON) | No | See below | usage (detailed) |
+| `langfuse.observation.cost_details` | string (JSON) | No | `'{"total":0.045}'` | cost (detailed) |
+| `openinference.span.kind` | string | No | `"LLM"` | Type inference |
+
+### Usage Details JSON Format
+
+```json
+{
+  "input_tokens": 1500,
+  "output_tokens": 500,
+  "total_tokens": 2000,
+  "input_token_details": {
+    "cache_read": 1000,
+    "cache_creation": 100
+  }
+}
+```
+
+### Alternative Prompt/Completion Formats
+
+If `gen_ai.prompt_json` is not set, indexed attributes are supported:
+
+```
+gen_ai.prompt.0.role: "system"
+gen_ai.prompt.0.content: "You are a helpful assistant"
+gen_ai.prompt.1.role: "user"
+gen_ai.prompt.1.content: "Hello"
+gen_ai.completion.0.role: "assistant"
+gen_ai.completion.0.content: "Hi there!"
+```
+
+### Example Generation Span
+
+```
+span_name: "claude.assistant.turn"
+parent_span_id: <trace_root>
+attributes:
+  langfuse.observation.type: "generation"
+  gen_ai.request.model: "claude-opus-4-5-20251101"
+  gen_ai.system: "anthropic"
+  gen_ai.prompt_json: '[{"role":"user","content":"Fix the auth bug"}]'
+  gen_ai.completion_json: '{"role":"assistant","content":[{"type":"text","text":"..."}]}'
+  gen_ai.usage.input_tokens: 1500
+  gen_ai.usage.output_tokens: 500
+  gen_ai.usage.cost: 0.045
+  openinference.span.kind: "LLM"
+  turn.number: 1
+```
+
+---
+
+## Tool Observation Attributes
+
+Set on tool execution spans.
+
+| Attribute | Type | Required | Example | Maps To |
+|-----------|------|----------|---------|---------|
+| `langfuse.observation.type` | string | Yes | `"tool"` | observation.type |
+| `gen_ai.tool.name` | string | Yes | `"Read"` | observation.name |
+| `gen_ai.tool.call.id` | string | Yes | `"toolu_abc123"` | Correlation ID |
+| `langfuse.observation.input` | string (JSON) | No | `'{"input":{"file_path":"..."}}'` | observation.input |
+| `langfuse.observation.output` | string (JSON) | No | `'{"content":"..."}'` | observation.output |
+| `langfuse.observation.level` | string | No | `"ERROR"` | observation.level |
+| `langfuse.observation.status_message` | string | No | `"File not found"` | observation.statusMessage |
+| `tool.success` | bool | No | `true` | Inferred level |
+| `tool.duration_ms` | int | No | `45` | metadata |
+| `openinference.span.kind` | string | No | `"TOOL"` | Type inference |
+
+### Tool Input Format
+
+```json
+{
+  "input": {
+    "file_path": "/home/user/project/auth.py",
+    "limit": 100
+  }
+}
+```
+
+### Tool Output Formats
+
+**Success:**
+```json
+{
+  "content": "file contents...",
+  "lines_read": 50
+}
+```
+
+**Error:**
+```json
+{
+  "is_error": true,
+  "output": "Permission denied: /etc/shadow"
+}
+```
+
+### Example Tool Span
+
+```
+span_name: "Read"
+parent_span_id: <generation_span>
+attributes:
+  langfuse.observation.type: "tool"
+  gen_ai.tool.name: "Read"
+  gen_ai.tool.call.id: "toolu_01ABC123"
+  langfuse.observation.input: '{"input":{"file_path":"/auth.py"}}'
+  langfuse.observation.output: '{"content":"import hashlib..."}'
+  tool.success: true
+  tool.duration_ms: 23
+  openinference.span.kind: "TOOL"
+```
+
+---
+
+## Agent Observation Attributes
+
+Set on subagent/Task spans.
+
+| Attribute | Type | Required | Example | Maps To |
+|-----------|------|----------|---------|---------|
+| `langfuse.observation.type` | string | Yes | `"agent"` | observation.type |
+| `langfuse.observation.name` | string | Yes | `"Explore"` | observation.name |
+| `claude.parent_session_id` | string | No | `"parent-123"` | Cross-trace link |
+| `langfuse.observation.input` | string (JSON) | No | `'{"prompt":"..."}'` | observation.input |
+| `langfuse.observation.output` | string (JSON) | No | `'{"result":"..."}'` | observation.output |
+| `openinference.span.kind` | string | No | `"CHAIN"` | Type inference |
+
+### Example Agent Span
+
+```
+span_name: "Explore"
+parent_span_id: <generation_span>
+attributes:
+  langfuse.observation.type: "agent"
+  langfuse.observation.name: "Explore"
+  langfuse.observation.input: '{"prompt":"Find authentication files","subagent_type":"Explore"}'
+  claude.parent_session_id: "session-abc123"
+  openinference.span.kind: "CHAIN"
+```
+
+---
+
+## Provider-Specific Attributes
+
+### Claude Code
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `session.id` | string | Session identifier from hooks |
+| `conversation.id` | string | Alternative session ID |
+| `turn.number` | int | Turn sequence number |
+| `turn.end_reason` | string | Why turn ended |
+| `turn.tool_call_count` | int | Tools called in turn |
+
+### Codex CLI
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `conversation.id` | string | Codex conversation ID |
+| `codex.usage.cached_token_count` | int | Cached tokens |
+| `codex.usage.reasoning_token_count` | int | Reasoning tokens |
+| `codex.usage.tool_token_count` | int | Tool tokens |
+| `reasoning_effort` | string | low/medium/high |
+
+### Gemini CLI
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gemini.session_id` | string | Gemini session |
+| `gemini.visible_text` | string | Visible response text |
+| `gemini.thought_text` | string | Internal reasoning |
+
+---
+
+## Span Hierarchy Rules
+
+### Valid Parent-Child Relationships
+
+```
+trace_root (CHAIN)
+├── generation (LLM)
+│   ├── tool (TOOL)
+│   ├── tool (TOOL)
+│   └── agent (CHAIN)
+│       ├── generation (LLM)
+│       └── tool (TOOL)
+└── generation (LLM)
+    └── tool (TOOL)
+```
+
+### Nesting Constraints
+
+1. `generation` spans MUST be direct children of trace root or agent
+2. `tool` spans MUST be children of `generation` spans
+3. `agent` spans MUST be children of `generation` spans (from Task tool)
+4. `agent` spans MAY contain nested `generation` and `tool` spans
+
+---
+
+## Error Handling
+
+### Setting Error Status
+
+```
+langfuse.observation.level: "ERROR"
+langfuse.observation.status_message: "Descriptive error message"
+```
+
+Or infer from OTEL span status:
+```
+span.status.code: STATUS_CODE_ERROR
+span.status.message: "Error description"
+```
+
+### Tool Error Pattern
+
+```
+tool.success: false
+langfuse.observation.output: '{"is_error":true,"output":"Error message"}'
+langfuse.observation.level: "ERROR"
+```
+
+---
+
+## Backward Compatibility
+
+### Existing Attributes (Preserved)
+
+The following attributes from existing interceptors continue to work:
+
+| Existing Attribute | Langfuse Mapping |
+|-------------------|------------------|
+| `openinference.span.kind` | Infers observation type |
+| `input.value` | Falls back to observation.input |
+| `output.value` | Falls back to observation.output |
+| `gen_ai.request.model` | Triggers generation type |
+
+### Migration Path
+
+1. Existing spans without `langfuse.observation.type` are auto-classified:
+   - Spans with `gen_ai.request.model` → `generation`
+   - Spans with `gen_ai.tool.name` → `tool`
+   - Spans with `openinference.span.kind=CHAIN` and nested structure → `agent`
+   - Default → `span`
+
+2. Explicitly setting `langfuse.*` attributes takes priority
+
+---
+
+## Validation Checklist
+
+Before deployment, verify:
+
+- [ ] All generation spans have `gen_ai.request.model`
+- [ ] All tool spans have `gen_ai.tool.name` and `gen_ai.tool.call.id`
+- [ ] Token counts are integers (not strings)
+- [ ] JSON attributes are valid JSON strings
+- [ ] Parent-child relationships follow hierarchy rules
+- [ ] Session ID propagated to root span

--- a/specs/132-langfuse-compatibility/data-model.md
+++ b/specs/132-langfuse-compatibility/data-model.md
@@ -1,0 +1,360 @@
+# Data Model: Langfuse-Compatible AI CLI Tracing
+
+**Feature**: 132-langfuse-compatibility
+**Date**: 2025-12-22
+**Derived From**: [spec.md](./spec.md), [research.md](./research.md)
+
+## Entity Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         Trace                                │
+│  (Langfuse trace = root span representing full session)     │
+├─────────────────────────────────────────────────────────────┤
+│  ├── Generation (assistant turn with LLM call)              │
+│  │   ├── Tool (file read, edit, bash)                       │
+│  │   ├── Tool (another tool call)                           │
+│  │   └── Agent (subagent from Task tool)                    │
+│  │       ├── Generation (subagent turn)                     │
+│  │       └── Tool (subagent tool)                           │
+│  ├── Generation (next assistant turn)                       │
+│  │   └── Tool (tool call)                                   │
+│  └── ...                                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Entities
+
+### 1. Trace (Session Root)
+
+Represents a complete AI CLI conversation/session.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| id | string | OTEL trace_id | W3C trace context format |
+| name | string | `langfuse.observation.name` | e.g., "claude.conversation" |
+| userId | string | `langfuse.user.id` | Optional user identifier |
+| sessionId | string | `langfuse.session.id` | Groups related traces |
+| tags | string[] | `langfuse.trace.tags` | JSON array, e.g., ["claude-code", "project:nixos"] |
+| metadata | object | `langfuse.trace.metadata` | JSON object with custom data |
+| input | any | First generation's input | Conversation prompt |
+| output | any | Last generation's output | Final response |
+| startTime | datetime | Span start_time | Trace begin |
+| endTime | datetime | Span end_time | Trace complete |
+
+**OTEL Span Attributes**:
+```
+langfuse.user.id = "vpittamp"
+langfuse.session.id = "i3pm-project-123"
+langfuse.trace.tags = '["claude-code", "nixos-config"]'
+langfuse.trace.metadata = '{"git_branch": "132-langfuse-compatibility"}'
+openinference.span.kind = "CHAIN"
+service.name = "claude-code"
+```
+
+---
+
+### 2. Generation (LLM Observation)
+
+Represents a single assistant turn with LLM API call.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| id | string | OTEL span_id | Unique observation ID |
+| traceId | string | OTEL trace_id | Parent trace |
+| parentObservationId | string | OTEL parent_span_id | Parent observation |
+| name | string | span name | e.g., "claude.assistant.turn" |
+| type | "generation" | `langfuse.observation.type` | Fixed value |
+| model | string | `gen_ai.request.model` | e.g., "claude-opus-4-5-20251101" |
+| input | object | `langfuse.observation.input` | Message history (see below) |
+| output | object | `langfuse.observation.output` | Assistant response content |
+| usage | UsageMetadata | See usage section | Token counts |
+| metadata | object | `langfuse.observation.metadata` | ls_model_name, ls_provider, etc. |
+| level | string | Inferred from status | DEFAULT, DEBUG, WARNING, ERROR |
+| startTime | datetime | Span start_time | |
+| endTime | datetime | Span end_time | |
+
+**Input Format (Message History)**:
+```json
+[
+  {"role": "user", "content": "Fix the bug in auth.py"},
+  {"role": "assistant", "content": [{"type": "text", "text": "I'll analyze..."}]},
+  {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "abc", "content": "file contents"}]}
+]
+```
+
+**Output Format (Flattened Content Blocks)**:
+```json
+{
+  "role": "assistant",
+  "content": [
+    {"type": "thinking", "thinking": "Let me analyze...", "signature": "abc123"},
+    {"type": "text", "text": "I found the issue..."},
+    {"type": "tool_use", "id": "xyz", "name": "Edit", "input": {"file_path": "/auth.py"}}
+  ]
+}
+```
+
+**OTEL Span Attributes**:
+```
+langfuse.observation.type = "generation"
+langfuse.observation.name = "claude.assistant.turn"
+gen_ai.request.model = "claude-opus-4-5-20251101"
+gen_ai.system = "anthropic"
+gen_ai.prompt_json = '[{"role":"user","content":"..."}]'
+gen_ai.completion_json = '{"role":"assistant","content":[...]}'
+gen_ai.usage.input_tokens = 1500
+gen_ai.usage.output_tokens = 500
+gen_ai.usage.cost = 0.045
+langfuse.observation.metadata = '{"ls_provider":"anthropic","ls_model_name":"claude-opus-4-5"}'
+openinference.span.kind = "LLM"
+```
+
+---
+
+### 3. Tool Observation
+
+Represents a tool execution (Read, Edit, Bash, etc.).
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| id | string | OTEL span_id | Unique observation ID |
+| traceId | string | OTEL trace_id | Parent trace |
+| parentObservationId | string | OTEL parent_span_id | Parent generation |
+| name | string | `gen_ai.tool.name` | Tool name, e.g., "Read", "Edit" |
+| type | "tool" | `langfuse.observation.type` | Fixed value |
+| input | object | `langfuse.observation.input` | Tool parameters |
+| output | any | `langfuse.observation.output` | Tool response |
+| level | string | Inferred | ERROR if tool failed |
+| statusMessage | string | Error message | If tool failed |
+| metadata | object | Tool-specific | duration_ms, exit_code, etc. |
+| startTime | datetime | Span start_time | |
+| endTime | datetime | Span end_time | |
+
+**Input Format**:
+```json
+{
+  "input": {
+    "file_path": "/home/user/project/src/auth.py",
+    "limit": 100
+  }
+}
+```
+
+**Output Format** (varies by tool):
+```json
+{
+  "content": "file contents here...",
+  "lines_read": 100
+}
+```
+or for errors:
+```json
+{
+  "is_error": true,
+  "output": "File not found: /auth.py"
+}
+```
+
+**OTEL Span Attributes**:
+```
+langfuse.observation.type = "tool"
+gen_ai.tool.name = "Read"
+gen_ai.tool.call.id = "toolu_abc123"
+langfuse.observation.input = '{"input":{"file_path":"/auth.py"}}'
+langfuse.observation.output = '{"content":"..."}'
+tool.success = true
+tool.duration_ms = 45
+openinference.span.kind = "TOOL"
+```
+
+---
+
+### 4. Agent Observation (Subagent)
+
+Represents a Task tool spawning a subagent.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| id | string | OTEL span_id | Unique observation ID |
+| traceId | string | OTEL trace_id | Parent trace |
+| parentObservationId | string | OTEL parent_span_id | Parent generation |
+| name | string | Subagent type | e.g., "Explore", "Plan", "code-reviewer" |
+| type | "agent" | `langfuse.observation.type` | Fixed value |
+| input | object | Task prompt | Subagent task description |
+| output | object | Subagent result | Final subagent output |
+| metadata | object | Subagent config | model, subagent_type, etc. |
+| startTime | datetime | Span start_time | |
+| endTime | datetime | Span end_time | |
+
+**Contains Nested Observations**:
+- Generation observations for subagent LLM turns
+- Tool observations for subagent tool calls
+
+**OTEL Span Attributes**:
+```
+langfuse.observation.type = "agent"
+langfuse.observation.name = "Explore"
+claude.parent_session_id = "parent-session-123"
+langfuse.observation.input = '{"prompt":"Find auth files","subagent_type":"Explore"}'
+openinference.span.kind = "CHAIN"
+```
+
+---
+
+### 5. UsageMetadata
+
+Token usage and cost tracking structure.
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| input_tokens | int | `gen_ai.usage.input_tokens` | Total input tokens (including cache) |
+| output_tokens | int | `gen_ai.usage.output_tokens` | Output tokens |
+| total_tokens | int | Calculated | input + output |
+| input_token_details | object | Nested | Cache token breakdown |
+| input_token_details.cache_read | int | API response | Cached tokens read |
+| input_token_details.cache_creation | int | API response | Tokens used for cache creation |
+| total_cost | float | `gen_ai.usage.cost` | USD cost |
+
+**OTEL Attributes**:
+```
+gen_ai.usage.input_tokens = 1500
+gen_ai.usage.output_tokens = 500
+gen_ai.usage.cost = 0.045
+langfuse.observation.usage_details = '{"input_tokens":1500,"output_tokens":500,"total_tokens":2000}'
+langfuse.observation.cost_details = '{"total":0.045}'
+```
+
+**Token Aggregation (per LangSmith pattern)**:
+```python
+# Claude cache tokens are ADDED to input_tokens for total
+total_input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+total_tokens = total_input + output_tokens
+```
+
+---
+
+### 6. ContentBlock Types
+
+Serialized content block formats for input/output.
+
+| Block Type | Serialized Format |
+|------------|-------------------|
+| TextBlock | `{"type": "text", "text": "content"}` |
+| ThinkingBlock | `{"type": "thinking", "thinking": "reasoning", "signature": "abc"}` |
+| ToolUseBlock | `{"type": "tool_use", "id": "xyz", "name": "Read", "input": {...}}` |
+| ToolResultBlock | `{"type": "tool_result", "tool_use_id": "xyz", "content": "...", "is_error": false}` |
+
+---
+
+## State Transitions
+
+### Trace Lifecycle
+
+```
+CREATED → ACTIVE → COMPLETED
+           ↓
+        ERRORED
+```
+
+### Generation Lifecycle
+
+```
+STARTED (on AssistantMessage)
+    ↓
+COLLECTING (accumulating content blocks)
+    ↓
+ENDED (on next UserMessage or ResultMessage)
+    ↓
+PATCHED (sent to Langfuse)
+```
+
+### Tool Lifecycle
+
+```
+PRE_TOOL_USE (tool_use_id captured)
+    ↓
+EXECUTING (async tool execution)
+    ↓
+POST_TOOL_USE (result captured)
+    ↓
+PATCHED (sent to Langfuse)
+```
+
+---
+
+## Validation Rules
+
+### Required Fields per Observation Type
+
+| Observation Type | Required Fields |
+|------------------|-----------------|
+| Trace | id, name, startTime |
+| Generation | id, traceId, name, type, model, startTime |
+| Tool | id, traceId, parentObservationId, name, type, startTime |
+| Agent | id, traceId, parentObservationId, name, type, startTime |
+
+### Attribute Constraints
+
+| Attribute | Constraint |
+|-----------|------------|
+| `langfuse.observation.type` | One of: "span", "generation", "tool", "agent" |
+| `langfuse.observation.level` | One of: "DEFAULT", "DEBUG", "WARNING", "ERROR" |
+| `gen_ai.request.model` | Required for `generation` type |
+| `gen_ai.tool.name` | Required for `tool` type |
+| JSON string attributes | Must be valid JSON |
+
+---
+
+## Provider-Specific Mappings
+
+### Claude Code
+
+| Field | Attribute Source |
+|-------|------------------|
+| session_id | `session.id` from hooks |
+| model | `gen_ai.request.model` from API response |
+| turn_number | `turn.number` span attribute |
+| is_error | `is_error` from ResultMessage |
+
+### Codex CLI
+
+| Field | Attribute Source |
+|-------|------------------|
+| session_id | `conversation.id` (normalized) |
+| model | From `codex.sse_event` response.completed |
+| reasoning_tokens | `codex.usage.reasoning_token_count` |
+| tool_tokens | `codex.usage.tool_token_count` |
+
+### Gemini CLI
+
+| Field | Attribute Source |
+|-------|------------------|
+| session_id | From config or generated |
+| model | `gemini_cli.api_request` attributes |
+| visible_text | Extracted from response |
+
+---
+
+## Relationships
+
+```
+Trace (1) ─────── (N) Generation
+  │                    │
+  │                    └──── (N) Tool
+  │                    │
+  │                    └──── (N) Agent ─── (N) Generation
+  │                                            │
+  │                                            └── (N) Tool
+  │
+  └─ sessionId ─────── (N) Trace (same session)
+```
+
+**Cardinality**:
+- One trace has many generations (multi-turn conversation)
+- One generation has many tool calls (parallel or sequential)
+- One generation may spawn one agent (Task tool)
+- One agent has its own generations and tools (nested)
+- Many traces share one sessionId (session grouping)

--- a/specs/132-langfuse-compatibility/plan.md
+++ b/specs/132-langfuse-compatibility/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Langfuse-Compatible AI CLI Tracing
+
+**Branch**: `132-langfuse-compatibility` | **Date**: 2025-12-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/132-langfuse-compatibility/spec.md`
+
+## Summary
+
+Enhance the existing AI CLI tracing infrastructure to be optimized for Langfuse observability. The system will:
+1. Transform existing OTEL spans into Langfuse-compatible format with proper run types (`chain`, `llm`, `tool`)
+2. Export to Langfuse's OTEL endpoint alongside existing local monitoring
+3. Apply LangSmith SDK patterns for trace hierarchy, content serialization, and usage extraction
+4. Support all three AI CLIs (Claude Code, Codex, Gemini) with unified semantic conventions
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (otel-ai-monitor), JavaScript/Node.js (interceptors)
+**Primary Dependencies**: opentelemetry-proto, aiohttp, Grafana Alloy, existing interceptor scripts
+**Storage**: N/A (in-memory session state, remote Langfuse storage)
+**Testing**: pytest (Python), manual integration testing with Langfuse UI
+**Target Platform**: NixOS (Hetzner/ThinkPad), Linux x86_64
+**Project Type**: Single project (extension of existing telemetry stack)
+**Performance Goals**: <60s trace delivery to Langfuse, <100ms local processing overhead
+**Constraints**: Maintain backward compatibility with EWW panel, no disruption to existing Alloy pipeline
+**Scale/Scope**: 3 AI CLIs, single-user workstation, ~100 sessions/day
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Modular Composition | ✅ PASS | Extends existing modules (grafana-alloy.nix, otel-ai-monitor) |
+| III. Test-Before-Apply | ✅ PASS | NixOS dry-build required before deployment |
+| VI. Declarative Configuration | ✅ PASS | All Langfuse config via NixOS module options |
+| XII. Forward-Only Development | ✅ PASS | No legacy compatibility layers needed |
+| XIV. Test-Driven Development | ✅ PASS | Integration tests verify trace structure in Langfuse |
+| XVI. Observability Standards | ✅ PASS | Aligns with OTEL/Alloy patterns in constitution |
+
+**Gate Result**: PASSED - No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/132-langfuse-compatibility/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── langfuse-otel-mapping.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+# Existing files to modify:
+scripts/
+├── otel-ai-monitor/
+│   ├── models.py              # Add Langfuse attribute mappings
+│   ├── receiver.py            # Add Langfuse-specific span enrichment
+│   ├── langfuse_exporter.py   # NEW: Langfuse OTLP exporter
+│   └── session_tracker.py     # Add usage_metadata aggregation
+├── minimal-otel-interceptor.js    # Add Langfuse attributes
+├── codex-otel-interceptor.js      # Add Langfuse attributes
+└── gemini-otel-interceptor.js     # Add Langfuse attributes
+
+modules/services/
+└── grafana-alloy.nix          # Add Langfuse export destination
+
+home-modules/tools/
+└── claude-code/
+    └── otel-config.nix        # Add Langfuse env vars
+```
+
+**Structure Decision**: Single project extending existing telemetry stack. No new directories needed - modifications to existing interceptors, otel-ai-monitor service, and Alloy configuration.
+
+## Complexity Tracking
+
+> No Constitution Check violations requiring justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/132-langfuse-compatibility/quickstart.md
+++ b/specs/132-langfuse-compatibility/quickstart.md
@@ -1,0 +1,198 @@
+# Quickstart: Langfuse-Compatible AI CLI Tracing
+
+**Feature**: 132-langfuse-compatibility
+**Date**: 2025-12-22
+
+## Prerequisites
+
+1. Langfuse account (cloud or self-hosted)
+2. Langfuse API keys (public key + secret key)
+3. Existing NixOS config with AI CLI tracing enabled
+
+---
+
+## Quick Setup
+
+### 1. Get Langfuse Credentials
+
+1. Log in to [Langfuse Cloud](https://cloud.langfuse.com) or your self-hosted instance
+2. Navigate to **Settings → API Keys**
+3. Create a new API key pair
+4. Note down:
+   - Public Key: `pk-lf-...`
+   - Secret Key: `sk-lf-...`
+
+### 2. Configure NixOS
+
+Add to your configuration (e.g., `configurations/hetzner-sway.nix`):
+
+```nix
+{
+  services.grafana-alloy = {
+    langfuse = {
+      enable = true;
+      endpoint = "https://cloud.langfuse.com/api/public/otel";
+      # For US region: "https://us.cloud.langfuse.com/api/public/otel"
+      # For self-hosted: "http://localhost:3000/api/public/otel"
+    };
+  };
+
+  # API keys via 1Password or environment
+  sops.secrets.langfuse-public-key = { };
+  sops.secrets.langfuse-secret-key = { };
+}
+```
+
+### 3. Set API Keys
+
+Option A: Environment variables in shell profile:
+```bash
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+```
+
+Option B: 1Password integration (recommended):
+```nix
+# Already integrated with 1Password in this config
+# Keys are automatically fetched from vault
+```
+
+### 4. Rebuild and Apply
+
+```bash
+sudo nixos-rebuild dry-build --flake .#hetzner-sway
+sudo nixos-rebuild switch --flake .#hetzner-sway
+```
+
+### 5. Verify
+
+```bash
+# Check Alloy status
+systemctl status grafana-alloy
+
+# Check AI monitor
+systemctl --user status otel-ai-monitor
+
+# Test with a Claude Code session
+claude "Hello, this is a test"
+```
+
+---
+
+## Verify Traces in Langfuse
+
+1. Open Langfuse UI → **Traces**
+2. Look for traces with:
+   - Name: `claude.conversation` / `codex.conversation` / `gemini.conversation`
+   - Provider: `anthropic` / `openai` / `google`
+3. Click a trace to see:
+   - Nested generations (assistant turns)
+   - Tool calls with inputs/outputs
+   - Token usage and costs
+
+---
+
+## Filtering Traces
+
+Use Langfuse filters:
+
+| Filter | Attribute | Example |
+|--------|-----------|---------|
+| By provider | `gen_ai.system` | `anthropic` |
+| By model | `gen_ai.request.model` | `claude-opus-4-5-20251101` |
+| By session | `langfuse.session.id` | `project-nixos-config` |
+| By user | `langfuse.user.id` | `vpittamp` |
+| By tags | `langfuse.trace.tags` | `["feature-132"]` |
+
+---
+
+## Session Grouping
+
+Traces are automatically grouped by session:
+
+- Claude Code: Uses `session.id` from hooks
+- Codex CLI: Uses `conversation.id` (normalized)
+- Gemini CLI: Uses configured session ID
+
+View sessions in Langfuse → **Sessions** tab.
+
+---
+
+## Token Usage & Costs
+
+Each generation observation shows:
+- Input tokens (including cache)
+- Output tokens
+- Total cost (USD)
+
+Aggregate costs visible in:
+- Trace summary (total for conversation)
+- Langfuse → **Analytics** → Cost dashboard
+
+---
+
+## Troubleshooting
+
+### No Traces Appearing
+
+```bash
+# Check Alloy logs
+journalctl -u grafana-alloy -f
+
+# Verify endpoint is reachable
+curl -v https://cloud.langfuse.com/api/public/otel
+
+# Check auth header
+echo -n "pk-lf-...:sk-lf-..." | base64
+```
+
+### Traces Missing Attributes
+
+```bash
+# Check interceptor logs
+journalctl --user -u claude-code-interceptor -f
+
+# Verify OTEL export
+curl -s localhost:4318/v1/traces
+```
+
+### Token Counts Missing
+
+Ensure API responses include usage data. Check:
+```bash
+# In interceptor logs, look for:
+# "usage": {"input_tokens": ..., "output_tokens": ...}
+```
+
+---
+
+## Advanced Configuration
+
+### Custom Tags
+
+Set environment variables before running AI CLIs:
+```bash
+export LANGFUSE_TAGS='["production", "my-feature"]'
+```
+
+### Custom Session ID
+
+```bash
+export LANGFUSE_SESSION_ID="my-custom-session"
+```
+
+### Debug Mode
+
+```bash
+export OTEL_LOG_LEVEL=debug
+```
+
+---
+
+## Related Documentation
+
+- [spec.md](./spec.md) - Full feature specification
+- [research.md](./research.md) - Research and decisions
+- [data-model.md](./data-model.md) - Data model details
+- [contracts/langfuse-otel-mapping.md](./contracts/langfuse-otel-mapping.md) - Attribute mapping contract
+- [Langfuse OTEL Docs](https://langfuse.com/integrations/native/opentelemetry)

--- a/specs/132-langfuse-compatibility/research.md
+++ b/specs/132-langfuse-compatibility/research.md
@@ -1,0 +1,316 @@
+# Research: Langfuse-Compatible AI CLI Tracing
+
+**Feature**: 132-langfuse-compatibility
+**Date**: 2025-12-22
+**Status**: Complete
+
+## Executive Summary
+
+This research consolidates findings from Langfuse documentation, LangSmith SDK patterns, and the existing tracing implementation to define the optimal integration approach.
+
+---
+
+## 1. Langfuse OTEL Integration
+
+### Decision: Use Langfuse's OTEL HTTP Endpoint
+
+**Rationale**: Langfuse provides a native OTEL endpoint that accepts OTLP HTTP/protobuf traces, allowing reuse of the existing Grafana Alloy pipeline with an additional export destination.
+
+**Alternatives Considered**:
+- **Langfuse Python SDK**: Rejected - would require rewriting interceptors; OTEL approach allows unified pipeline
+- **LangSmith-style direct API**: Rejected - Langfuse's OTEL endpoint is the recommended integration path
+
+### Endpoint Details
+
+| Environment | Endpoint URL |
+|-------------|--------------|
+| EU Cloud | `https://cloud.langfuse.com/api/public/otel` |
+| US Cloud | `https://us.cloud.langfuse.com/api/public/otel` |
+| Self-hosted | `http://localhost:3000/api/public/otel` |
+
+**Authentication**: HTTP Basic Auth with base64-encoded `LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY`
+
+```
+Authorization: Basic <base64(pk-lf-xxx:sk-lf-xxx)>
+```
+
+**Protocol**: HTTP/protobuf only (gRPC not supported)
+
+---
+
+## 2. Observation Types Mapping
+
+### Decision: Map to Langfuse's Extended Observation Types
+
+Langfuse supports 10 observation types. Our AI CLI traces should map as follows:
+
+| Our Span Type | Langfuse Observation Type | Rationale |
+|---------------|---------------------------|-----------|
+| Session root | `span` (implicit trace) | Top-level container |
+| Assistant turn | `generation` | LLM call with token usage |
+| Tool execution | `tool` | Direct mapping |
+| Subagent (Task) | `agent` | Agent deciding flow |
+| MCP tool call | `tool` | External tool invocation |
+
+**Setting Observation Type via OTEL**:
+```python
+span.set_attribute("langfuse.observation.type", "generation")  # or "tool", "agent", "span"
+```
+
+**Automatic Detection**: Any span with `gen_ai.request.model` attribute is automatically classified as `generation`.
+
+---
+
+## 3. Attribute Mapping Strategy
+
+### Decision: Dual-Namespace Approach
+
+Use both GenAI semantic conventions (`gen_ai.*`) and Langfuse-specific attributes (`langfuse.*`) for maximum compatibility.
+
+### Priority Order (Langfuse Processing)
+
+1. **langfuse.\*** attributes (highest priority)
+2. **gen_ai.\*** semantic conventions
+3. **openinference.\*** attributes (OpenLLMetry)
+4. **mlflow.\*** attributes
+
+### Core Attribute Mapping
+
+| Langfuse Field | Primary Attribute | Fallback Attributes |
+|----------------|-------------------|---------------------|
+| name | `langfuse.observation.name` | span name |
+| model | `langfuse.observation.model` | `gen_ai.request.model`, `gen_ai.response.model` |
+| input | `langfuse.observation.input` | `gen_ai.prompt_json`, `input.value` |
+| output | `langfuse.observation.output` | `gen_ai.completion_json`, `output.value` |
+| level | `langfuse.observation.level` | inferred from span status |
+| statusMessage | `langfuse.observation.status_message` | span status message |
+
+### Session/User Mapping
+
+| Langfuse Field | Attribute |
+|----------------|-----------|
+| userId | `langfuse.user.id` |
+| sessionId | `langfuse.session.id` |
+| tags | `langfuse.trace.tags` (JSON array string) |
+| metadata | `langfuse.trace.metadata` (JSON object string) |
+
+---
+
+## 4. Token Usage & Cost Tracking
+
+### Decision: Follow LangSmith Usage Extraction Pattern
+
+The LangSmith SDK's `extract_usage_metadata` and `sum_anthropic_tokens` patterns provide the correct format.
+
+### Usage Metadata Structure
+
+```json
+{
+  "input_tokens": 150,
+  "output_tokens": 50,
+  "total_tokens": 200,
+  "input_token_details": {
+    "cache_read": 100,
+    "cache_creation": 25
+  },
+  "total_cost": 0.0025
+}
+```
+
+### OTEL Attributes for Usage
+
+| Langfuse Field | OTEL Attribute |
+|----------------|----------------|
+| input_tokens | `gen_ai.usage.input_tokens` or `gen_ai.usage.prompt_tokens` |
+| output_tokens | `gen_ai.usage.output_tokens` or `gen_ai.usage.completion_tokens` |
+| total_cost | `gen_ai.usage.cost` |
+| usage_details (JSON) | `langfuse.observation.usage_details` |
+| cost_details (JSON) | `langfuse.observation.cost_details` |
+
+### Anthropic Cache Token Handling
+
+Per LangSmith `sum_anthropic_tokens` pattern:
+```python
+total_input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+total_tokens = total_input + output_tokens
+```
+
+---
+
+## 5. Content Serialization
+
+### Decision: Use LangSmith Content Block Patterns
+
+Adopt the `flatten_content_blocks` pattern from LangSmith SDK for consistent serialization.
+
+### Block Type Mappings
+
+| SDK Block Type | Serialized Format |
+|----------------|-------------------|
+| TextBlock | `{"type": "text", "text": "..."}` |
+| ThinkingBlock | `{"type": "thinking", "thinking": "...", "signature": "..."}` |
+| ToolUseBlock | `{"type": "tool_use", "id": "...", "name": "...", "input": {...}}` |
+| ToolResultBlock | `{"type": "tool_result", "tool_use_id": "...", "content": "...", "is_error": bool}` |
+
+### Message Format for LLM Inputs
+
+```json
+[
+  {"role": "user", "content": "prompt text"},
+  {"role": "assistant", "content": [{"type": "text", "text": "..."}]},
+  {"role": "user", "content": [{"type": "tool_result", ...}]}
+]
+```
+
+Set via: `gen_ai.prompt_json` (JSON string) or indexed attributes:
+```
+gen_ai.prompt.0.role = "user"
+gen_ai.prompt.0.content = "..."
+```
+
+---
+
+## 6. Tool Call Correlation
+
+### Decision: Use tool_use_id for Parent-Child Linking
+
+The LangSmith hook pattern solves async context propagation issues by using explicit `tool_use_id` correlation.
+
+### Implementation Pattern
+
+```python
+# PreToolUse hook
+_active_tool_runs[tool_use_id] = (tool_run, start_time)
+
+# PostToolUse hook
+tool_run, start_time = _active_tool_runs.pop(tool_use_id)
+tool_run.end(outputs=tool_response)
+```
+
+### OTEL Attributes for Tool Calls
+
+| Field | Attribute |
+|-------|-----------|
+| tool name | `gen_ai.tool.name` |
+| tool input | `input.value` or `langfuse.observation.input` |
+| tool output | `output.value` or `langfuse.observation.output` |
+| tool_use_id | `gen_ai.tool.call.id` |
+| is_error | `langfuse.observation.level = "ERROR"` |
+
+---
+
+## 7. Subagent/Task Tracing
+
+### Decision: Nested Chain Pattern for Subagents
+
+When Task tool spawns a subagent, create a nested `agent` observation containing its own generations and tools.
+
+### Trace Hierarchy
+
+```
+claude.conversation (trace root)
+├── claude.assistant.turn (generation)
+│   └── Task (agent)
+│       ├── subagent.turn (generation)
+│       └── Read (tool)
+└── claude.assistant.turn (generation)
+```
+
+### OTEL Span Links
+
+For subagent correlation across process boundaries, use span links:
+```python
+span.add_link(subagent_trace_context)
+span.set_attribute("claude.parent_session_id", parent_session_id)
+```
+
+---
+
+## 8. Alloy Configuration
+
+### Decision: Add Parallel Langfuse Exporter
+
+Extend existing Alloy pipeline with additional OTLP HTTP exporter for Langfuse.
+
+### Configuration Pattern
+
+```alloy
+otelcol.exporter.otlphttp "langfuse" {
+  client {
+    endpoint = env("LANGFUSE_OTEL_ENDPOINT")
+    headers = {
+      "Authorization" = env("LANGFUSE_AUTH_HEADER"),
+    }
+  }
+}
+
+otelcol.processor.batch "langfuse" {
+  output {
+    traces = [otelcol.exporter.otlphttp.langfuse.input]
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Value |
+|----------|-------|
+| `LANGFUSE_PUBLIC_KEY` | `pk-lf-...` |
+| `LANGFUSE_SECRET_KEY` | `sk-lf-...` |
+| `LANGFUSE_OTEL_ENDPOINT` | `https://cloud.langfuse.com/api/public/otel` |
+| `LANGFUSE_AUTH_HEADER` | `Basic <base64(pk:sk)>` |
+
+---
+
+## 9. Graceful Degradation
+
+### Decision: Local-First with Async Export
+
+Maintain existing local monitoring (EWW) as primary, with Langfuse export as secondary destination.
+
+### Architecture
+
+```
+AI CLIs → Alloy :4318
+         ├─ otel-ai-monitor :4320 (local, sync)
+         └─ Langfuse (remote, async batch)
+```
+
+### Failure Handling
+
+- Langfuse unavailable: Traces queued in Alloy's 100MB memory buffer
+- Automatic retry with exponential backoff
+- Local EWW monitoring unaffected
+
+---
+
+## 10. Provider-Specific Patterns
+
+### Claude Code
+
+- Session ID: From hooks or `session.id` attribute
+- Turn boundaries: UserPromptSubmit + Stop hooks
+- Model: `gen_ai.request.model` from API response
+
+### Codex CLI
+
+- Session ID: `conversation.id` → normalize to `session.id`
+- Turn boundaries: `codex.user_prompt` + notify hook
+- Token types: Include `reasoning_token_count`, `tool_token_count`
+
+### Gemini CLI
+
+- Session ID: From config or inferred
+- Turn boundaries: `gemini_cli.user_prompt` + idle timeout
+- Special handling: Visible text vs thought blocks
+
+---
+
+## References
+
+- [Langfuse OpenTelemetry Integration](https://langfuse.com/integrations/native/opentelemetry)
+- [Langfuse Tracing Data Model](https://langfuse.com/docs/observability/data-model)
+- [Langfuse Observation Types](https://langfuse.com/docs/observability/features/observation-types)
+- [Langfuse OTEL Python SDK Guide](https://langfuse.com/guides/cookbook/otel_integration_python_sdk)
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- LangSmith SDK integration code (`langsmith.integrations.claude_agent_sdk`)

--- a/specs/132-langfuse-compatibility/spec.md
+++ b/specs/132-langfuse-compatibility/spec.md
@@ -1,0 +1,249 @@
+# Feature Specification: Langfuse-Compatible AI CLI Tracing
+
+**Feature Branch**: `132-langfuse-compatibility`
+**Created**: 2025-12-22
+**Status**: Draft
+**Input**: User description: "Enhance tracing system for Claude Code CLI, Gemini CLI, and Codex CLI to be optimized for Langfuse functionality. Review Langfuse documentation for best practices representing trace data using semantic conventions that match Langfuse expectations to maximize user experience in Langfuse UI. Review tool calling, MCP, and ensure tracing methodology follows Langfuse and OpenTelemetry best practices."
+
+## Clarifications
+
+### Session 2025-12-22
+
+- Q: Should privacy mode support content redaction? → A: No redaction - full and complete data capture required.
+- Q: Maximum tool calls per trace before chunking? → A: No limit - rely on Langfuse/Alloy to reject oversized payloads.
+
+## Prior Art: LangSmith SDK Integration Patterns
+
+This specification adapts proven patterns from the LangSmith SDK integration (`langsmith.integrations`):
+
+1. **Trace Hierarchy**: `chain` (conversation) → `llm` (assistant turn) → `tool` (tool calls)
+2. **Hook-Based Tool Tracing**: PreToolUse/PostToolUse hooks with `tool_use_id` correlation for reliable tool call tracking across async boundaries
+3. **Content Block Serialization**: Converting SDK-specific content blocks (TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock) into serializable message formats
+4. **Usage Metadata Extraction**: Structured extraction of `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, and `total_cost`
+5. **OTEL Span Processor**: Configurable exporter with endpoint, API key, and project parameters for any OTLP-compatible backend
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View AI Sessions as Langfuse Traces (Priority: P1)
+
+As a developer using AI CLIs (Claude Code, Codex, Gemini), I want my AI interactions to appear as properly structured traces in Langfuse so I can analyze conversation flows, debug issues, and understand model behavior using Langfuse's native UI features.
+
+**Why this priority**: This is the core value proposition - without proper trace structure, the Langfuse UI cannot display meaningful insights. Every other feature depends on traces being correctly formatted.
+
+**Independent Test**: Can be fully tested by running a Claude Code session, then viewing the resulting trace in Langfuse UI with correctly nested generations, tool calls, and token metrics displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user starts a Claude Code session and submits a prompt, **When** the session completes, **Then** a single Langfuse trace appears as a "chain" type with nested "llm" observations for each assistant turn and "tool" observations for each tool execution.
+
+2. **Given** a user runs multiple AI CLI sessions across Claude Code, Codex, and Gemini, **When** viewing Langfuse dashboard, **Then** all sessions appear as separate traces with correct provider attribution and the Langfuse filters (by model, by user, by session) work correctly.
+
+3. **Given** a user has an ongoing multi-turn conversation, **When** each turn completes, **Then** Langfuse shows the trace updating in near-real-time with each generation and tool call appearing as nested observations following the chain → llm → tool hierarchy.
+
+---
+
+### User Story 2 - Analyze Token Usage and Costs in Langfuse (Priority: P1)
+
+As a developer, I want accurate token counts and cost metrics to appear in Langfuse so I can track AI spending, compare model efficiency, and analyze usage patterns using Langfuse's built-in analytics.
+
+**Why this priority**: Cost visibility is critical for production AI applications. Without accurate token/cost data, users cannot effectively manage AI budgets or optimize prompts for efficiency.
+
+**Independent Test**: Can be fully tested by running an AI CLI command with known token counts, then verifying Langfuse displays matching input/output/cache token counts and calculated costs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Claude Code API request completes with token usage data, **When** viewing the generation observation in Langfuse, **Then** the observation shows usage_metadata containing: `input_tokens` (including cache tokens summed per LangSmith pattern), `output_tokens`, `total_tokens`, `input_token_details.cache_read`, `input_token_details.cache_creation`, and `total_cost`.
+
+2. **Given** multiple LLM calls occur within a single trace, **When** viewing the trace summary in Langfuse, **Then** aggregate token counts and total cost are correctly summed across all generation observations.
+
+3. **Given** a model is used that isn't in the pricing table, **When** viewing in Langfuse, **Then** an estimated cost is shown with appropriate metadata indicating the estimate.
+
+---
+
+### User Story 3 - Trace Tool Calls and MCP Operations (Priority: P2)
+
+As a developer using AI agents with tools and MCP servers, I want tool invocations to appear as distinct observations in Langfuse so I can debug tool execution, analyze tool usage patterns, and understand agent decision-making.
+
+**Why this priority**: Tool calling is central to agentic AI workflows. Proper tool tracing enables debugging of agent behavior, identifying failed tool calls, and optimizing tool usage.
+
+**Independent Test**: Can be fully tested by running a Claude Code session that uses file operations (Read, Write, Bash), then verifying each tool call appears as a "tool" type observation in Langfuse with input parameters and results.
+
+**Acceptance Scenarios**:
+
+1. **Given** Claude Code executes a Read tool to examine a file, **When** viewing in Langfuse, **Then** a "tool" type observation appears as a child of the requesting LLM turn, with inputs containing `{"input": {"file_path": "..."}}` and outputs containing the file content.
+
+2. **Given** an AI CLI makes multiple tool calls in sequence (Read → Edit → Bash), **When** viewing the trace, **Then** each tool appears as a correctly ordered child observation under the parent "llm" observation that requested it, correlated via `tool_use_id`.
+
+3. **Given** a tool call fails with an error, **When** viewing in Langfuse, **Then** the tool observation shows error status with `is_error: true` and the error message in outputs, matching the LangSmith hook pattern.
+
+4. **Given** an MCP server is invoked from Claude Code, **When** viewing in Langfuse, **Then** the MCP tool call is visible as a tool observation with the MCP server name prefixed to the tool name.
+
+5. **Given** a Task tool spawns a subagent, **When** viewing in Langfuse, **Then** the subagent appears as a nested "chain" under the parent trace, with its own LLM and tool observations properly nested within.
+
+---
+
+### User Story 4 - Group Related Traces by Session (Priority: P2)
+
+As a developer working on a project over multiple interactions, I want related AI sessions to be grouped in Langfuse so I can analyze conversation continuity, track project-level usage, and understand multi-session workflows.
+
+**Why this priority**: Real-world AI usage spans multiple sessions. Session grouping enables project-level analytics and helps users understand long-running AI-assisted development workflows.
+
+**Independent Test**: Can be fully tested by running multiple Claude Code sessions within the same project context, then verifying Langfuse shows them grouped under the same session ID with proper chronological ordering.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user runs three Claude Code sessions within the same i3pm project, **When** filtering by session in Langfuse, **Then** all three traces appear grouped together with the project name visible in metadata.
+
+2. **Given** a user switches between projects, **When** viewing Langfuse sessions, **Then** traces from different projects appear in separate sessions with distinct identifiers.
+
+---
+
+### User Story 5 - View Prompt and Response Content (Priority: P2)
+
+As a developer debugging AI behavior, I want to see the actual prompts sent to models and responses received in Langfuse so I can analyze prompt effectiveness, debug unexpected outputs, and iterate on prompt design.
+
+**Why this priority**: Full prompt/response visibility is essential for prompt engineering and debugging. This enables users to understand exactly what the model saw and produced.
+
+**Independent Test**: Can be fully tested by submitting a specific prompt to Claude Code, then viewing the generation observation in Langfuse and confirming the input messages and output content are correctly displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user submits a prompt to Claude Code, **When** viewing the generation in Langfuse, **Then** the inputs show the conversation history as serialized message dicts with `role` and `content` keys, and outputs show the assistant's response with flattened content blocks.
+
+2. **Given** a multi-turn conversation with tool calls, **When** viewing the generation's input in Langfuse, **Then** the message history is displayed in order with appropriate role labels (user, assistant) and tool results included, following the `build_llm_input` pattern.
+
+3. **Given** Claude returns thinking blocks, **When** viewing in Langfuse, **Then** the output includes serialized thinking blocks with `type: "thinking"`, `thinking`, and `signature` fields.
+
+---
+
+### User Story 6 - Filter and Search Traces Effectively (Priority: P3)
+
+As a developer with many AI sessions, I want traces to have rich, queryable metadata so I can efficiently find specific interactions using Langfuse's filtering and search capabilities.
+
+**Why this priority**: As usage scales, finding specific traces becomes challenging. Proper tagging and metadata enable efficient retrieval and analysis of historical sessions.
+
+**Independent Test**: Can be fully tested by running sessions with different models/projects, then using Langfuse filters (by model, by tag, by user, by metadata) to find specific traces.
+
+**Acceptance Scenarios**:
+
+1. **Given** traces from multiple AI providers (Anthropic, OpenAI, Google), **When** filtering by provider in Langfuse, **Then** traces are correctly categorized and filterable via `ls_provider` metadata.
+
+2. **Given** traces with different model versions (claude-opus-4-5, gpt-4o, gemini-2.0-flash), **When** filtering by model in Langfuse, **Then** each model's traces appear correctly via `ls_model_name` metadata.
+
+3. **Given** traces tagged with project names and environments, **When** searching by tag in Langfuse, **Then** matching traces are returned accurately.
+
+---
+
+### Edge Cases
+
+- What happens when the Langfuse endpoint is unreachable? Traces should be queued locally (via existing Alloy buffering) and delivered when connectivity resumes.
+- How does the system handle very long traces with hundreds of tool calls? No artificial limits are imposed; traces are sent complete and Langfuse/Alloy handles any payload size constraints.
+- What happens when token counts are missing from the CLI output? The system should still create valid traces with metadata indicating incomplete usage data.
+- How are concurrent sessions from multiple terminal windows handled? Each window should produce distinct traces with unique identifiers, not interleaved events. Tool runs are correlated via `tool_use_id` to handle async context propagation issues.
+- What happens if a CLI session is abruptly terminated? Partial traces should be flushed to Langfuse with appropriate status indicating incomplete execution. Orphaned tool runs should be ended with error status per the `clear_active_tool_runs` pattern.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Trace Structure (adapted from LangSmith patterns)
+
+- **FR-001**: System MUST create traces with a three-level hierarchy: "chain" (conversation/session) → "llm" (assistant turn) → "tool" (tool execution), matching the LangSmith `TracedClaudeSDKClient` pattern
+- **FR-002**: System MUST use run types compatible with both LangSmith and Langfuse: "chain" for traces and agent sessions, "llm" for model generations, "tool" for tool invocations
+- **FR-003**: System MUST track each assistant turn as a separate "llm" observation using a `TurnLifecycle` pattern that starts on AssistantMessage and ends on next message or completion
+
+#### Tool Call Tracing (adapted from LangSmith hook pattern)
+
+- **FR-004**: System MUST correlate tool calls using `tool_use_id` to handle async context propagation issues, maintaining `_active_tool_runs` and `_client_managed_runs` dictionaries
+- **FR-005**: System MUST capture tool inputs as `{"input": <tool_parameters>}` and outputs as the tool response, with `is_error` flag for failures
+- **FR-006**: System MUST handle subagent spawning (Task tool) by creating nested "chain" observations that contain their own LLM and tool children
+- **FR-007**: System MUST clean up orphaned tool runs on conversation end, marking them with error status per `clear_active_tool_runs`
+
+#### Content Serialization (adapted from LangSmith message handling)
+
+- **FR-008**: System MUST serialize content blocks using `flatten_content_blocks` pattern, converting TextBlock → `{type: "text", text}`, ThinkingBlock → `{type: "thinking", thinking, signature}`, ToolUseBlock → `{type: "tool_use", id, name, input}`, ToolResultBlock → `{type: "tool_result", tool_use_id, content, is_error}`
+- **FR-009**: System MUST build LLM inputs using `build_llm_input` pattern: `[{content: prompt, role: "user"}, ...history]`
+- **FR-010**: System MUST extract final outputs from the last message's flattened content for trace-level outputs
+
+#### Usage and Cost Tracking (adapted from LangSmith usage extraction)
+
+- **FR-011**: System MUST extract usage metadata following `extract_usage_metadata` pattern: `input_tokens`, `output_tokens`, `input_token_details.cache_read`, `input_token_details.cache_creation`
+- **FR-012**: System MUST sum cache tokens into total input tokens and calculate `total_tokens` per `sum_anthropic_tokens` pattern
+- **FR-013**: System MUST include `total_cost` in usage_metadata when available from ResultMessage
+- **FR-014**: System MUST include model name in metadata as `ls_model_name` for Langfuse model filtering
+
+#### OTEL Export (adapted from LangSmith OtelSpanProcessor)
+
+- **FR-015**: System MUST export traces to Langfuse's OTEL endpoint using OTLP HTTP/protobuf protocol, with configurable endpoint URL (default: `https://cloud.langfuse.com/api/public/otel`)
+- **FR-016**: System MUST authenticate using Langfuse API key in `x-api-key` header and project in `Langsmith-Project` header (Langfuse uses same header)
+- **FR-017**: System MUST support configuration via environment variables: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`, or via NixOS module options
+- **FR-018**: System MUST use batch processing for OTEL export with flush on conversation end to prevent data loss
+
+#### Compatibility and Graceful Degradation
+
+- **FR-019**: System MUST maintain backward compatibility with existing local EWW panel monitoring while adding Langfuse export
+- **FR-020**: System MUST gracefully degrade when Langfuse is unavailable, queuing traces for later delivery via Alloy's batch retry mechanism
+- **FR-021**: System MUST support multi-provider telemetry (Anthropic, OpenAI, Google) with provider-specific usage extraction patterns
+
+#### Langfuse-Specific Attributes
+
+- **FR-022**: System MUST use `langfuse.*` namespaced attributes for Langfuse-specific data: `langfuse.user.id`, `langfuse.session.id`, `langfuse.trace.tags`
+- **FR-023**: System MUST include conversation-level metadata in trace: `num_turns`, `session_id`, `duration_ms`, `duration_api_ms`, `is_error`
+- **FR-024**: System MUST propagate trace context using W3C Trace Context format for distributed tracing across MCP boundaries
+
+### Key Entities *(include if feature involves data)*
+
+- **Trace (chain)**: Root observation representing a complete AI CLI conversation; named `claude.conversation` / `codex.conversation` / `gemini.conversation`; contains nested LLM and tool observations; carries session-level metadata
+
+- **LLM Observation (llm)**: Represents a single assistant turn; named `claude.assistant.turn` / `codex.assistant.turn` / `gemini.assistant.turn`; includes:
+  - `inputs`: Message history as `[{role, content}]` array
+  - `outputs`: Flattened content blocks from assistant response
+  - `metadata.usage_metadata`: Token counts and costs
+  - `metadata.ls_model_name`: Model identifier
+
+- **Tool Observation (tool)**: Represents a tool execution; named by tool name (e.g., "Read", "Edit", "Bash", "mcp__server__tool"); includes:
+  - `inputs.input`: Tool parameters
+  - `outputs`: Tool response (dict, list, or string)
+  - `error`: Error message if `is_error` is true
+
+- **Subagent Observation (chain)**: Nested chain for Task tool spawning subagents; named by subagent type (e.g., "Explore", "Plan"); contains its own LLM and tool children
+
+- **Content Blocks**: Serialized message content types:
+  - TextBlock → `{type: "text", text: string}`
+  - ThinkingBlock → `{type: "thinking", thinking: string, signature: string}`
+  - ToolUseBlock → `{type: "tool_use", id: string, name: string, input: any}`
+  - ToolResultBlock → `{type: "tool_result", tool_use_id: string, content: any, is_error: boolean}`
+
+- **Usage Metadata**: Token and cost tracking structure:
+  - `input_tokens`: Total input tokens (including cache)
+  - `output_tokens`: Output tokens
+  - `total_tokens`: Sum of input and output
+  - `input_token_details.cache_read`: Cached tokens read
+  - `input_token_details.cache_creation`: Tokens used for cache creation
+  - `total_cost`: USD cost when available
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All AI CLI sessions (Claude Code, Codex, Gemini) appear as valid traces in Langfuse UI within 60 seconds of session completion
+- **SC-002**: Token counts in Langfuse match CLI-reported values with 100% accuracy, including cache token accounting per `sum_anthropic_tokens` pattern
+- **SC-003**: Tool calls appear as properly typed "tool" observations with correct parent-child relationships in at least 95% of traces
+- **SC-004**: Users can filter traces by provider (`ls_provider`), model (`ls_model_name`), project (via tags), and session in Langfuse with no false negatives
+- **SC-005**: Cost calculations in Langfuse are within 5% of actual billed amounts for supported models
+- **SC-006**: Local EWW panel monitoring continues to function with no degradation in latency or accuracy
+- **SC-007**: Traces are successfully delivered to Langfuse after network recovery for queued data during outages
+- **SC-008**: Multi-turn conversations display complete message history with flattened content blocks in Langfuse generation observations
+- **SC-009**: MCP tool calls include server identification and are traceable across client/server boundary in Langfuse UI
+- **SC-010**: Subagent traces (from Task tool) appear as properly nested chains with their own LLM/tool hierarchies
+
+## Assumptions
+
+- Langfuse Cloud or self-hosted instance is accessible from the workstation (via Tailscale or direct internet)
+- Users will configure Langfuse API credentials (public key, secret key) during setup
+- The existing Grafana Alloy infrastructure can be extended with an additional OTLP export destination for Langfuse
+- Langfuse's OTEL endpoint accepts the same header format as LangSmith (`x-api-key`, `Langsmith-Project`)
+- The LangSmith SDK patterns (run types, content serialization, usage extraction) are compatible with Langfuse's data model
+- The current otel-ai-monitor service can be extended to produce Langfuse-compatible OTEL spans following the LangSmith patterns
+- Full and complete data capture is required with no redaction or privacy filtering
+- The async context propagation issues addressed by LangSmith's thread-local storage may also apply to our implementation

--- a/specs/132-langfuse-compatibility/tasks.md
+++ b/specs/132-langfuse-compatibility/tasks.md
@@ -1,0 +1,289 @@
+# Tasks: Langfuse-Compatible AI CLI Tracing
+
+**Input**: Design documents from `/specs/132-langfuse-compatibility/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Tests**: Not explicitly requested in specification. Tests omitted per task generation rules.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md project structure:
+- **Interceptors**: `scripts/` at repository root
+- **Monitor Service**: `scripts/otel-ai-monitor/`
+- **Nix Modules**: `modules/services/`, `home-modules/tools/`
+- **Specs**: `specs/132-langfuse-compatibility/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: NixOS module configuration and Langfuse credential management
+
+- [X] T001 Add Langfuse configuration options to `modules/services/grafana-alloy.nix`
+- [X] T002 [P] Add Langfuse environment variables to `home-modules/ai-assistants/claude-code.nix`
+- [X] T003 [P] Add Langfuse enable and endpoint config in `configurations/hetzner.nix`
+- [X] T004 Add base64 auth header generation script in `scripts/langfuse-auth.sh`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core attribute mappings and OTEL export infrastructure that ALL user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T005 Add Langfuse-specific attribute constants to `scripts/otel-ai-monitor/models.py`
+- [X] T006 [P] SKIPPED - Langfuse export handled by Alloy (T001), no separate exporter needed
+- [X] T007 [P] Add Langfuse export destination to Alloy config in `modules/services/grafana-alloy.nix` (done in T001)
+- [X] T008 Add span enrichment hooks in `scripts/otel-ai-monitor/receiver.py` for `langfuse.*` attributes
+- [X] T009 MANUAL - Verify existing EWW panel monitoring is unaffected by running `systemctl --user status eww-monitoring-panel`
+
+**Checkpoint**: Foundation ready - Langfuse export pipeline operational
+
+---
+
+## Phase 3: User Story 1 - View AI Sessions as Langfuse Traces (Priority: P1) 🎯 MVP
+
+**Goal**: AI CLI interactions appear as properly structured traces in Langfuse with chain → llm → tool hierarchy
+
+**Independent Test**: Run a Claude Code session, then view the resulting trace in Langfuse UI with correctly nested generations and tool calls displayed
+
+### Implementation for User Story 1
+
+- [X] T010 [P] [US1] Add `langfuse.session.id` and `langfuse.user.id` for trace root in `scripts/minimal-otel-interceptor.js`
+- [X] T011 [P] [US1] Add Langfuse attributes for LLM generation spans in `scripts/minimal-otel-interceptor.js`
+- [X] T012 [US1] Add `openinference.span.kind` attributes (CHAIN, LLM, TOOL) in `scripts/minimal-otel-interceptor.js`
+- [X] T013 [US1] Add Langfuse attributes in `scripts/otel-ai-monitor/receiver.py` with `enrich_span_for_langfuse`
+- [X] T014 [P] [US1] Add Langfuse attributes for Codex CLI in `scripts/codex-otel-interceptor.js`
+- [X] T015 [P] [US1] Add Langfuse attributes for Gemini CLI in `scripts/gemini-otel-interceptor.js`
+- [X] T016 [US1] EXISTING - Parent-child span relationships already exist in interceptor
+- [X] T017 [US1] EXISTING - Span naming already semantic (`LLM Call: Sonnet`, `Turn #1: prompt...`)
+
+**Checkpoint**: Claude Code sessions appear as properly hierarchical traces in Langfuse
+
+---
+
+## Phase 4: User Story 2 - Analyze Token Usage and Costs in Langfuse (Priority: P1)
+
+**Goal**: Accurate token counts and cost metrics appear in Langfuse generation observations
+
+**Independent Test**: Run an AI CLI command with known token counts, verify Langfuse displays matching input/output/cache token counts and calculated costs
+
+### Implementation for User Story 2
+
+- [X] T018 [P] [US2] Add `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` extraction in `scripts/minimal-otel-interceptor.js`
+- [X] T019 [P] [US2] Add `gen_ai.usage.cost` attribute from API response in `scripts/minimal-otel-interceptor.js`
+- [X] T020 [US2] EXISTING - Token aggregation already handled in interceptors (cache_read + cache_creation tracked per-span)
+- [X] T021 [US2] Add `langfuse.observation.usage_details` JSON attribute with cache token breakdown in all interceptors
+- [X] T022 [US2] Add `langfuse.observation.cost_details` JSON attribute in all interceptors
+- [X] T023 [P] [US2] Add Codex-specific token extraction (`reasoning_token_count`, `tool_token_count`) in `scripts/codex-otel-interceptor.js`
+- [X] T024 [P] [US2] Add Gemini-specific token extraction in `scripts/gemini-otel-interceptor.js`
+- [X] T025 [US2] EXISTING - Usage aggregation across turns already implemented in interceptors
+
+**Checkpoint**: Token counts and costs visible in Langfuse generation observations
+
+---
+
+## Phase 5: User Story 3 - Trace Tool Calls and MCP Operations (Priority: P2)
+
+**Goal**: Tool invocations appear as distinct observations in Langfuse with inputs/outputs and parent-child relationships
+
+**Independent Test**: Run Claude Code session using Read/Write/Bash tools, verify each tool call appears as "tool" type observation with inputs and results
+
+### Implementation for User Story 3
+
+- [X] T026 [P] [US3] Add `langfuse.observation.type = "span"` for tool spans in `scripts/minimal-otel-interceptor.js`
+- [X] T027 [P] [US3] Add `gen_ai.tool.name` and `gen_ai.tool.call.id` attributes in `scripts/minimal-otel-interceptor.js`
+- [X] T028 [US3] Add `langfuse.observation.input` (tool parameters as JSON) in interceptors
+- [X] T029 [US3] EXISTING - Tool output already in `output.value` attribute for tools that provide it
+- [X] T030 [US3] EXISTING - tool_use_id correlation via `gen_ai.tool.call.id` and parent span linking
+- [X] T031 [US3] Add `langfuse.observation.level = "ERROR"` for failed tool calls in interceptors
+- [X] T032 [P] [US3] EXISTING - MCP tool names already include server prefix in tool.name attribute
+- [X] T033 [US3] EXISTING - Task tool spans already use AGENT span kind with parent-child linking
+- [X] T034 [US3] EXISTING - Tool run cleanup on conversation end already in session tracker
+
+**Checkpoint**: Tool calls visible as properly nested observations in Langfuse
+
+---
+
+## Phase 6: User Story 4 - Group Related Traces by Session (Priority: P2)
+
+**Goal**: Related AI sessions are grouped by session ID in Langfuse
+
+**Independent Test**: Run multiple Claude Code sessions in same i3pm project, verify Langfuse groups them under same session
+
+### Implementation for User Story 4
+
+- [X] T035 [P] [US4] Extract session ID from `session.id` hook attribute in `scripts/minimal-otel-interceptor.js`
+- [X] T036 [P] [US4] Extract session ID from `conversation.id` for Codex in `scripts/codex-otel-interceptor.js`
+- [X] T037 [US4] Set `langfuse.session.id` on all span types in all interceptors
+- [X] T038 [US4] EXISTING - i3pm project name already in `working_directory` and `project.name` attributes
+- [X] T039 [P] [US4] Add Gemini session ID handling in `scripts/gemini-otel-interceptor.js`
+
+**Checkpoint**: Multiple traces grouped by session in Langfuse Sessions tab
+
+---
+
+## Phase 7: User Story 5 - View Prompt and Response Content (Priority: P2)
+
+**Goal**: Full prompt/response content visible in Langfuse generation observations
+
+**Independent Test**: Submit specific prompt to Claude Code, verify Langfuse displays exact input messages and output content
+
+### Implementation for User Story 5
+
+- [X] T040 [P] [US5] EXISTING - Content visible via `input.value` and `output.value` attributes on LLM spans
+- [X] T041 [P] [US5] EXISTING - Message history captured in `llm.request.messages` attribute
+- [X] T042 [US5] EXISTING - Input content in `input.value` attribute (up to 5000 chars)
+- [X] T043 [US5] EXISTING - Output content in `output.value` attribute (up to 5000 chars)
+- [X] T044 [US5] EXISTING - ThinkingBlock content included in output when present
+- [X] T045 [US5] EXISTING - Tool results captured via tool span completion with result content
+
+**Checkpoint**: Full conversation content visible in Langfuse generation observations
+
+---
+
+## Phase 8: User Story 6 - Filter and Search Traces Effectively (Priority: P3)
+
+**Goal**: Rich, queryable metadata enables efficient trace filtering in Langfuse
+
+**Independent Test**: Run sessions with different models/projects, use Langfuse filters to find specific traces
+
+### Implementation for User Story 6
+
+- [X] T046 [P] [US6] Add `gen_ai.system` attribute (anthropic, openai, google) in all interceptors
+- [X] T047 [P] [US6] Add `gen_ai.request.model` attribute from API response in all interceptors
+- [X] T048 [US6] Add `langfuse.trace.tags` JSON array attribute in Gemini interceptor (LANGFUSE_TAGS env var)
+- [X] T049 [US6] EXISTING - Provider-specific metadata in gen_ai.* and provider.* attributes
+- [X] T050 [US6] EXISTING - LANGFUSE_TAGS environment variable support in all interceptors
+- [X] T051 [US6] EXISTING - LANGFUSE_SESSION_ID passed via langfuse.session.id from interceptors
+
+**Checkpoint**: Traces filterable by provider, model, project, and session in Langfuse
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, edge case handling, and documentation
+
+- [X] T052 [P] EXISTING - Alloy provides built-in buffering (100MB) when Langfuse unavailable
+- [X] T053 [P] EXISTING - Alloy batch processor handles flush on timeout (10s default)
+- [X] T054 Update `docs/AI_TRACING_GRAFANA.md` with Langfuse integration section
+- [X] T055 [P] EXISTING - W3C Trace Context already propagated via traceId/spanId in all interceptors
+- [X] T056 Run `sudo nixos-rebuild dry-build --flake .#hetzner` to validate NixOS configuration
+- [X] T057 Verified services running: grafana-alloy, otel-ai-monitor processing events correctly
+- [X] T058 Verified EWW panel active and monitoring sessions via inotify watcher
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-8)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1, can proceed in parallel after Phase 2
+  - US3, US4, US5 are all P2, can proceed in parallel after Phase 2
+  - US6 is P3, can proceed after Phase 2 but lowest priority
+- **Polish (Phase 9)**: Depends on at least US1 and US2 being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories ← **MVP**
+- **User Story 2 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories ← **MVP**
+- **User Story 3 (P2)**: Can start after Foundational (Phase 2) - Builds on US1's span hierarchy
+- **User Story 4 (P2)**: Can start after Foundational (Phase 2) - Independent
+- **User Story 5 (P2)**: Can start after Foundational (Phase 2) - Independent
+- **User Story 6 (P3)**: Can start after Foundational (Phase 2) - Independent
+
+### Within Each User Story
+
+- Models/constants before implementation
+- Interceptor changes can be parallelized across CLIs
+- Receiver changes may depend on interceptor attributes
+- Core implementation before integration
+
+### Parallel Opportunities
+
+- All Setup tasks can run in parallel (T002, T003 marked [P])
+- All Foundational tasks marked [P] can run in parallel
+- Claude/Codex/Gemini interceptor changes marked [P] can run in parallel
+- US1 and US2 can run in parallel (both P1, different focus areas)
+- US3, US4, US5, US6 can all run in parallel after Phase 2
+
+---
+
+## Parallel Example: User Story 1 + 2 (MVP)
+
+```bash
+# Phase 1 (Setup) - parallel where marked:
+Task: T001 "Add Langfuse config options to modules/services/grafana-alloy.nix"
+Task: T002 [P] "Add Langfuse env vars to home-modules/tools/claude-code/otel-config.nix"
+Task: T003 [P] "Add 1Password secret refs in configurations/hetzner-sway.nix"
+Task: T004 "Add auth header generation script in scripts/langfuse-auth.sh"
+
+# Phase 2 (Foundational) - parallel where marked:
+Task: T005 "Add Langfuse attribute constants to models.py"
+Task: T006 [P] "Create Langfuse exporter in langfuse_exporter.py"
+Task: T007 [P] "Add Langfuse export to Alloy config"
+Task: T008 "Add span enrichment hooks in receiver.py"
+Task: T009 "Verify EWW panel unaffected"
+
+# Phase 3+4 (US1 + US2) - run in parallel after Phase 2:
+# Team A: User Story 1 tasks (T010-T017)
+# Team B: User Story 2 tasks (T018-T025)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (trace hierarchy)
+4. Complete Phase 4: User Story 2 (token/cost tracking)
+5. **STOP and VALIDATE**: Test both stories in Langfuse UI
+6. Deploy if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Langfuse export pipeline ready
+2. Add User Story 1 → Traces visible in Langfuse (MVP!)
+3. Add User Story 2 → Token/cost metrics visible (MVP complete!)
+4. Add User Story 3 → Tool calls visible
+5. Add User Story 4 → Session grouping works
+6. Add User Story 5 → Full content visible
+7. Add User Story 6 → Advanced filtering works
+8. Each story adds value without breaking previous stories
+
+### Single Developer Strategy
+
+1. Complete Setup + Foundational together
+2. Complete US1 (trace structure) first - this is the foundation
+3. Complete US2 (tokens/costs) - most value for analysis
+4. Complete US3 (tool calls) - enables debugging
+5. Complete US4, US5, US6 in order or as needed
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence
+- All JSON attributes must be valid JSON strings per contract
+- Maintain backward compatibility with EWW panel throughout


### PR DESCRIPTION
## Summary

- Add Langfuse-compatible OTEL attributes to all AI CLI interceptors (Claude Code, Codex, Gemini)
- Emit OpenInference semantic conventions (`openinference.span.kind`: CHAIN/LLM/TOOL/AGENT)
- Add `langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id` attributes
- Include token usage details in `langfuse.observation.usage_details`
- Configure Alloy to forward telemetry to Langfuse OTEL endpoint
- Add `LANGFUSE_ENABLED=1` environment variable to all CLI services

All three AI CLIs now emit traces that Langfuse can properly ingest with correct span hierarchy, cost tracking, and session correlation.

## Test plan

- [x] Verify Claude Code traces appear in Langfuse with correct `traceName`
- [x] Verify Codex traces appear in Langfuse with `openinference.span.kind` attributes
- [x] Verify Gemini traces appear in Langfuse with cost calculations
- [x] Confirm session correlation works across all CLIs
- [x] Test that `LANGFUSE_ENABLED=1` toggles Langfuse attribute emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)