### PR TITLE
Unify AI terminal window visibility tracking

### DIFF
--- a/home-modules/desktop/i3-project-event-daemon/handlers.py
+++ b/home-modules/desktop/i3-project-event-daemon/handlers.py
@@ -27,6 +27,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _container_is_in_scratchpad(container) -> bool:
+    """Return True when a container is currently attached to the scratchpad tree."""
+    parent = container
+    while parent:
+        scratchpad_state = str(getattr(parent, "scratchpad_state", "") or "").strip().lower()
+        if scratchpad_state and scratchpad_state != "none":
+            return True
+        parent = getattr(parent, "parent", None)
+    return False
+
+
 # ============================================================================
 # Feature 101: Window Tracing Integration
 # ============================================================================
@@ -889,6 +900,7 @@ async def on_window_new(
                 if container.workspace() and getattr(container.workspace(), "ipc_data", None)
                 else ""
             ),
+            binding_state="bound_workspace" if container.workspace() else "transient_unbound",
             created=datetime.now(),
             # Feature 041 T022: Store correlation metadata if matched via launch
             # T040: Now using full signals from calculate_confidence including workspace details
@@ -1399,6 +1411,12 @@ async def on_window_new(
                 project=active_project,
                 marks=[],
                 workspace=container.workspace().name if container.workspace() else "",
+                output=(
+                    container.workspace().ipc_data.get("output", "")
+                    if container.workspace() and getattr(container.workspace(), "ipc_data", None)
+                    else ""
+                ),
+                binding_state="bound_workspace" if container.workspace() else "transient_unbound",
                 created=datetime.now(),
             )
 
@@ -2019,18 +2037,42 @@ async def on_window_move(
         # Feature 102 Fix: Record trace event BEFORE early return for scratchpad windows
         # This ensures windows moving to __i3_scratch are still traced
         if not workspace:
-            logger.debug(f"Window {window_id} has no workspace (likely scratchpad), recording trace and skipping tracking")
+            in_scratchpad = _container_is_in_scratchpad(container)
+            binding_state = "scratchpad_hidden" if in_scratchpad else "transient_unbound"
+            logger.debug(
+                "Window %s has no workspace, preserving tracked binding as %s",
+                window_id,
+                binding_state,
+            )
+            await state_manager.update_window(
+                window_id,
+                binding_state=binding_state,
+                workspace="scratchpad" if in_scratchpad else "",
+                is_floating=is_floating,
+            )
             # Record scratchpad move event
             await _record_trace_event(
                 container,
-                "scratchpad::move",
-                f"Window moved to scratchpad",
-                {"window_class": window_class, "floating": is_floating}
+                "scratchpad::move" if in_scratchpad else "window::move",
+                "Window moved to scratchpad" if in_scratchpad else "Window temporarily lost workspace binding",
+                {"window_class": window_class, "floating": is_floating, "binding_state": binding_state}
             )
             return
 
         workspace_num = workspace.num
         workspace_name = workspace.name
+        workspace_output = (
+            workspace.ipc_data.get("output", "")
+            if getattr(workspace, "ipc_data", None)
+            else ""
+        )
+        await state_manager.update_window(
+            window_id,
+            workspace=workspace_name,
+            output=workspace_output,
+            is_floating=is_floating,
+            binding_state="bound_workspace",
+        )
 
         # Feature 053 Phase 6: Comprehensive window::move event logging
         log_event_entry(

--- a/home-modules/desktop/i3-project-event-daemon/ipc_server.py
+++ b/home-modules/desktop/i3-project-event-daemon/ipc_server.py
@@ -2776,7 +2776,138 @@ class IPCServer:
             "terminal_anchor_id": str(getattr(tracked_window, "terminal_anchor_id", "") or ""),
             "app_key": str(getattr(tracked_window, "app_identifier", "") or ""),
             "app_name": str(getattr(tracked_window, "app_identifier", "") or ""),
+            "binding_state": str(getattr(tracked_window, "binding_state", "") or ""),
+            "last_workspace": str(getattr(tracked_window, "last_workspace", "") or ""),
+            "last_output": str(getattr(tracked_window, "last_output", "") or ""),
+            "last_visible": bool(getattr(tracked_window, "last_visible", True)),
         }
+
+    def _workspace_number_from_label(self, workspace_name: str) -> int:
+        """Parse a workspace label into a stable numeric ordering key."""
+        workspace = str(workspace_name or "").strip()
+        if workspace.lower() == "scratchpad":
+            return -1
+        match = re.match(r"^(\d+)", workspace)
+        if match:
+            return int(match.group(1))
+        return 0
+
+    def _project_outputs_from_tracked_windows(
+        self,
+        outputs: List[Dict[str, Any]],
+        tracked_windows: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Project workspace windows from canonical tracked window state."""
+        projected_outputs: List[Dict[str, Any]] = []
+        output_index: Dict[str, Dict[str, Any]] = {}
+        workspace_index: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+        for raw_output in outputs:
+            if not isinstance(raw_output, dict):
+                continue
+            output_name = str(raw_output.get("name") or "").strip()
+            projected_output = {
+                "name": output_name,
+                "active": bool(raw_output.get("active", False)),
+                "primary": bool(raw_output.get("primary", False)),
+                "geometry": dict(raw_output.get("geometry", {}) or {}),
+                "current_workspace": str(raw_output.get("current_workspace") or "").strip(),
+                "workspaces": [],
+            }
+            for raw_workspace in list(raw_output.get("workspaces", []) or []):
+                if not isinstance(raw_workspace, dict):
+                    continue
+                workspace_name = str(raw_workspace.get("name") or "").strip()
+                projected_workspace = {
+                    "number": int(raw_workspace.get("number") or self._workspace_number_from_label(workspace_name)),
+                    "name": workspace_name,
+                    "focused": bool(raw_workspace.get("focused", False)),
+                    "visible": bool(raw_workspace.get("visible", False)),
+                    "output": output_name,
+                    "windows": [],
+                }
+                projected_output["workspaces"].append(projected_workspace)
+                workspace_index[(output_name, workspace_name)] = projected_workspace
+            projected_outputs.append(projected_output)
+            output_index[output_name] = projected_output
+
+        fallback_output_name = str(projected_outputs[0].get("name") or "").strip() if projected_outputs else ""
+
+        for tracked_window in tracked_windows:
+            if not isinstance(tracked_window, dict):
+                continue
+            binding_state = str(tracked_window.get("binding_state") or "").strip() or "bound_workspace"
+            workspace_name = str(
+                tracked_window.get("workspace")
+                or tracked_window.get("last_workspace")
+                or ""
+            ).strip()
+            output_name = str(
+                tracked_window.get("output")
+                or tracked_window.get("last_output")
+                or fallback_output_name
+            ).strip()
+            if not workspace_name or not output_name:
+                continue
+
+            projected_output = output_index.get(output_name)
+            if projected_output is None:
+                projected_output = {
+                    "name": output_name,
+                    "active": True,
+                    "primary": False,
+                    "geometry": {},
+                    "current_workspace": "",
+                    "workspaces": [],
+                }
+                projected_outputs.append(projected_output)
+                output_index[output_name] = projected_output
+
+            workspace_key = (output_name, workspace_name)
+            projected_workspace = workspace_index.get(workspace_key)
+            if projected_workspace is None:
+                projected_workspace = {
+                    "number": self._workspace_number_from_label(workspace_name),
+                    "name": workspace_name,
+                    "focused": False,
+                    "visible": False,
+                    "output": output_name,
+                    "windows": [],
+                }
+                projected_output["workspaces"].append(projected_workspace)
+                workspace_index[workspace_key] = projected_workspace
+
+            projected_workspace["windows"].append({
+                "id": int(tracked_window.get("window_id") or tracked_window.get("id") or 0),
+                "title": str(tracked_window.get("title") or "(untitled)"),
+                "app_key": str(tracked_window.get("app_key") or ""),
+                "app_name": str(tracked_window.get("app_name") or tracked_window.get("window_class") or "window"),
+                "icon_path": str(tracked_window.get("icon_path") or "").strip(),
+                "project": str(tracked_window.get("project") or "").strip(),
+                "scope": str(tracked_window.get("scope") or "").strip(),
+                "workspace": workspace_name,
+                "output": output_name,
+                "focused": bool(tracked_window.get("focused", False)),
+                "hidden": binding_state == "scratchpad_hidden",
+                "visible": binding_state != "scratchpad_hidden",
+                "floating": bool(tracked_window.get("floating", False)),
+                "execution_mode": str(tracked_window.get("execution_mode") or "").strip(),
+                "connection_key": str(tracked_window.get("connection_key") or "").strip(),
+                "context_key": str(tracked_window.get("context_key") or "").strip(),
+                "binding_state": binding_state,
+            })
+
+        for projected_output in projected_outputs:
+            workspaces = list(projected_output.get("workspaces", []) or [])
+            workspaces.sort(
+                key=lambda workspace: (
+                    int(workspace.get("number") or self._workspace_number_from_label(str(workspace.get("name") or ""))),
+                    str(workspace.get("name") or ""),
+                )
+            )
+            projected_output["workspaces"] = workspaces
+
+        return projected_outputs
 
     def _resolve_window_icon_path(
         self,
@@ -11696,13 +11827,20 @@ rm -f -- "$0" >/dev/null 2>&1 || true
             window_instance = str(getattr(window_info, "window_instance", "") or "")
             window_id = int(getattr(window_info, "window_id", 0) or 0)
             visible_window = visible_windows_by_id.get(window_id, {})
+            tracked_binding_state = str(getattr(window_info, "binding_state", "") or "").strip()
+            tracked_last_workspace = str(getattr(window_info, "last_workspace", "") or "").strip()
+            tracked_last_output = str(getattr(window_info, "last_output", "") or "").strip()
             scope = str(
                 visible_window.get("scope")
                 or getattr(window_info, "scope", "")
                 or "global"
             )
-            hidden = bool(visible_window.get("hidden", False)) if visible_window else True
-            visible = bool(visible_window) and not hidden
+            if visible_window:
+                binding_state = "scratchpad_hidden" if bool(visible_window.get("hidden", False)) else "bound_workspace"
+            else:
+                binding_state = tracked_binding_state or "transient_unbound"
+            hidden = binding_state == "scratchpad_hidden"
+            visible = binding_state != "scratchpad_hidden"
             icon_path = self._resolve_window_icon_path(
                 app_key=str(visible_window.get("app_key") or app_key or ""),
                 app_id=visible_window.get("app_id") or app_key,
@@ -11720,8 +11858,18 @@ rm -f -- "$0" >/dev/null 2>&1 || true
                     "con_id": int(getattr(window_info, "con_id", 0) or 0),
                     "project": str(visible_window.get("project") or getattr(window_info, "project", "") or ""),
                     "scope": scope,
-                    "workspace": str(visible_window.get("workspace") or getattr(window_info, "workspace", "") or ""),
-                    "output": str(visible_window.get("output") or getattr(window_info, "output", "") or ""),
+                    "workspace": str(
+                        visible_window.get("workspace")
+                        or getattr(window_info, "workspace", "")
+                        or tracked_last_workspace
+                        or ""
+                    ),
+                    "output": str(
+                        visible_window.get("output")
+                        or getattr(window_info, "output", "")
+                        or tracked_last_output
+                        or ""
+                    ),
                     "title": str(
                         visible_window.get("title")
                         or getattr(window_info, "window_title", "")
@@ -11785,6 +11933,9 @@ rm -f -- "$0" >/dev/null 2>&1 || true
                     "focused": bool(visible_window.get("focused", False)),
                     "visible": visible,
                     "hidden": hidden,
+                    "binding_state": binding_state,
+                    "last_workspace": tracked_last_workspace,
+                    "last_output": tracked_last_output,
                     "floating": (
                         bool(visible_window.get("floating", False))
                         if visible_window
@@ -11795,6 +11946,8 @@ rm -f -- "$0" >/dev/null 2>&1 || true
                     "tmux_session_name": str(getattr(window_info, "tmux_session_name", "") or ""),
                 }
             )
+
+        outputs = self._project_outputs_from_tracked_windows(outputs, tracked_window_list)
 
         active_context_key = str(active_context.get("context_key") or "").strip()
         active_project_name = str(active_context.get("qualified_name") or active_context.get("project_name") or "").strip()
@@ -11845,7 +11998,7 @@ rm -f -- "$0" >/dev/null 2>&1 || true
             "active_context": active_context,
             "outputs": outputs,
             "active_outputs": active_outputs,
-            "total_windows": int(tree_result.get("total_windows", 0) or 0) if isinstance(tree_result, dict) else 0,
+            "total_windows": len(tracked_window_list),
             "cached_window_tree": bool(tree_result.get("cached", False)) if isinstance(tree_result, dict) else False,
             "tracked_windows": tracked_window_list,
             "state_health": {

--- a/home-modules/desktop/i3-project-event-daemon/models/legacy.py
+++ b/home-modules/desktop/i3-project-event-daemon/models/legacy.py
@@ -43,6 +43,10 @@ class WindowInfo:
     workspace: str = ""  # Current workspace name
     output: str = ""  # Current monitor/output name
     is_floating: bool = False  # Floating vs. tiled
+    binding_state: str = "bound_workspace"  # bound_workspace | scratchpad_hidden | transient_unbound
+    last_workspace: str = ""  # Durable last bound workspace for transient rebinds
+    last_output: str = ""  # Durable last bound output for transient rebinds
+    last_visible: bool = True  # Whether the window was last represented as visible
 
     # Timestamps
     created: datetime = field(default_factory=datetime.now)
@@ -80,6 +84,18 @@ class WindowInfo:
             raise ValueError(f"Invalid window_id: {self.window_id}")
         if self.con_id <= 0:
             raise ValueError(f"Invalid con_id: {self.con_id}")
+        if not self.last_workspace and self.workspace:
+            self.last_workspace = self.workspace
+        if not self.last_output and self.output:
+            self.last_output = self.output
+        state = str(self.binding_state or "").strip() or ("bound_workspace" if self.workspace else "transient_unbound")
+        if state not in {"bound_workspace", "scratchpad_hidden", "transient_unbound"}:
+            state = "bound_workspace" if self.workspace else "transient_unbound"
+        self.binding_state = state
+        if self.binding_state == "scratchpad_hidden":
+            self.last_visible = False
+        else:
+            self.last_visible = True
 
 
 # Feature 030: Standalone Project model (remove i3_project_manager dependency)

--- a/home-modules/desktop/i3-project-event-daemon/state.py
+++ b/home-modules/desktop/i3-project-event-daemon/state.py
@@ -18,6 +18,42 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def _normalize_window_runtime(window_info: WindowInfo) -> None:
+    """Keep tracked window binding state and durable workspace/output in sync."""
+    state = str(getattr(window_info, "binding_state", "") or "").strip()
+    if state not in {"bound_workspace", "scratchpad_hidden", "transient_unbound"}:
+        state = "bound_workspace" if getattr(window_info, "workspace", "") else "transient_unbound"
+        window_info.binding_state = state
+
+    workspace = str(getattr(window_info, "workspace", "") or "").strip()
+    output = str(getattr(window_info, "output", "") or "").strip()
+
+    if state == "bound_workspace":
+        if workspace:
+            window_info.last_workspace = workspace
+        if output:
+            window_info.last_output = output
+        window_info.last_visible = True
+    elif state == "scratchpad_hidden":
+        if workspace and workspace.lower() != "scratchpad":
+            window_info.last_workspace = workspace
+        if output:
+            window_info.last_output = output
+        if not workspace:
+            window_info.workspace = "scratchpad"
+        window_info.last_visible = False
+    else:
+        if workspace:
+            window_info.last_workspace = workspace
+        elif getattr(window_info, "last_workspace", ""):
+            window_info.workspace = window_info.last_workspace
+        if output:
+            window_info.last_output = output
+        elif getattr(window_info, "last_output", ""):
+            window_info.output = window_info.last_output
+        window_info.last_visible = True
+
+
 class StateManager:
     """Manages runtime state for the daemon with async-safe operations."""
 
@@ -51,6 +87,7 @@ class StateManager:
             window_info: WindowInfo object to add
         """
         async with self._lock:
+            _normalize_window_runtime(window_info)
             self.state.window_map[window_info.window_id] = window_info
             logger.debug(
                 f"Added window {window_info.window_id} "
@@ -94,6 +131,7 @@ class StateManager:
                     logger.debug(f"Updated window {window_id}: {key}={value}")
                 else:
                     logger.warning(f"Unknown window property: {key}")
+            _normalize_window_runtime(window_info)
 
     async def get_window(self, window_id: int) -> Optional[WindowInfo]:
         """Get window by ID.
@@ -299,6 +337,7 @@ class StateManager:
                         remote_tmux_window=str(window_env.remote_tmux_window or "") if window_env else "",
                         remote_tmux_pane=str(window_env.remote_tmux_pane or "") if window_env else "",
                     )
+                    _normalize_window_runtime(window_info)
 
                     self.state.window_map[tracked_window_id] = window_info
                     count += 1

--- a/home-modules/desktop/i3-project-event-daemon/tests/unit/test_handlers_window_move.py
+++ b/home-modules/desktop/i3-project-event-daemon/tests/unit/test_handlers_window_move.py
@@ -1,0 +1,105 @@
+"""Regression tests for managed window move handling."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+PACKAGE_ROOT = Path(__file__).parent.parent.parent
+
+
+if "i3_project_daemon" not in sys.modules:
+    package_spec = importlib.util.spec_from_file_location(
+        "i3_project_daemon",
+        PACKAGE_ROOT / "__init__.py",
+        submodule_search_locations=[str(PACKAGE_ROOT)],
+    )
+    package_module = importlib.util.module_from_spec(package_spec)
+    sys.modules["i3_project_daemon"] = package_module
+    assert package_spec.loader is not None
+    package_spec.loader.exec_module(package_module)
+
+
+handlers_module = importlib.import_module("i3_project_daemon.handlers")
+
+
+@pytest.mark.asyncio
+async def test_window_move_without_workspace_preserves_transient_binding():
+    state_manager = SimpleNamespace(
+        update_window=AsyncMock(),
+        increment_error_count=AsyncMock(),
+        get_active_project=AsyncMock(return_value="vpittamp/nixos-config:main"),
+    )
+    ipc_server = SimpleNamespace(
+        invalidate_window_tree_cache=Mock(),
+        notify_state_change=AsyncMock(),
+    )
+
+    container = SimpleNamespace(
+        id=101,
+        floating="user_on",
+        parent=None,
+        workspace=lambda: None,
+    )
+    event = SimpleNamespace(container=container)
+
+    await handlers_module.on_window_move(
+        conn=None,
+        event=event,
+        state_manager=state_manager,
+        workspace_tracker=None,
+        event_buffer=None,
+        ipc_server=ipc_server,
+    )
+
+    state_manager.update_window.assert_awaited_once_with(
+        101,
+        binding_state="transient_unbound",
+        workspace="",
+        is_floating=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_window_move_into_scratchpad_marks_hidden_binding():
+    state_manager = SimpleNamespace(
+        update_window=AsyncMock(),
+        increment_error_count=AsyncMock(),
+        get_active_project=AsyncMock(return_value="vpittamp/nixos-config:main"),
+    )
+    ipc_server = SimpleNamespace(
+        invalidate_window_tree_cache=Mock(),
+        notify_state_change=AsyncMock(),
+    )
+
+    scratchpad_parent = SimpleNamespace(scratchpad_state="changed", parent=None)
+    container = SimpleNamespace(
+        id=102,
+        floating="auto_on",
+        parent=scratchpad_parent,
+        workspace=lambda: None,
+    )
+    event = SimpleNamespace(container=container)
+
+    await handlers_module.on_window_move(
+        conn=None,
+        event=event,
+        state_manager=state_manager,
+        workspace_tracker=None,
+        event_buffer=None,
+        ipc_server=ipc_server,
+    )
+
+    state_manager.update_window.assert_awaited_once_with(
+        102,
+        binding_state="scratchpad_hidden",
+        workspace="scratchpad",
+        is_floating=True,
+    )

--- a/home-modules/desktop/i3-project-event-daemon/tests/unit/test_ipc_server_session_list.py
+++ b/home-modules/desktop/i3-project-event-daemon/tests/unit/test_ipc_server_session_list.py
@@ -29,8 +29,10 @@ if "i3_project_daemon" not in sys.modules:
 
 
 ipc_server_module = importlib.import_module("i3_project_daemon.ipc_server")
+models_module = importlib.import_module("i3_project_daemon.models")
 
 IPCServer = ipc_server_module.IPCServer
+WindowInfo = models_module.WindowInfo
 
 
 class DummyLaunchRegistry:
@@ -81,6 +83,76 @@ def make_runtime_snapshot():
             }
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_keeps_transient_unbound_window_visible(server, monkeypatch):
+    tracked_window = WindowInfo(
+        window_id=101,
+        con_id=101,
+        window_class="com.mitchellh.ghostty",
+        window_title="Ghostty",
+        window_instance="ghostty",
+        app_identifier="terminal",
+        project="vpittamp/nixos-config:main",
+        marks=["scoped:terminal:vpittamp/nixos-config:main:101"],
+        scope="scoped",
+        workspace="1",
+        output="eDP-1",
+        binding_state="transient_unbound",
+        last_workspace="1",
+        last_output="eDP-1",
+    )
+
+    async def fake_context_get_active(_params):
+        return {
+            "qualified_name": "vpittamp/nixos-config:main",
+            "project_name": "vpittamp/nixos-config:main",
+            "execution_mode": "local",
+            "connection_key": "local@thinkpad",
+            "context_key": "vpittamp/nixos-config:main::local::local@thinkpad",
+        }
+
+    async def fake_window_map_snapshot():
+        return {101: tracked_window}
+
+    server._get_window_tree = AsyncMock(return_value={
+        "outputs": [
+            {
+                "name": "eDP-1",
+                "active": True,
+                "primary": True,
+                "geometry": {},
+                "current_workspace": "1",
+                "workspaces": [
+                    {
+                        "number": 1,
+                        "name": "1",
+                        "focused": True,
+                        "visible": True,
+                        "output": "eDP-1",
+                        "windows": [],
+                    }
+                ],
+            }
+        ],
+        "total_windows": 0,
+        "cached": False,
+    })
+    monkeypatch.setattr(server, "_context_get_active", fake_context_get_active)
+    monkeypatch.setattr(server.state_manager, "get_window_map_snapshot", fake_window_map_snapshot, raising=False)
+    monkeypatch.setattr(server, "_get_reusable_context_terminal_window", AsyncMock(return_value=None))
+    monkeypatch.setattr(server, "_get_launch_stats", AsyncMock(return_value={}))
+
+    snapshot = await server._runtime_snapshot({})
+
+    assert snapshot["total_windows"] == 1
+    assert snapshot["tracked_windows"][0]["binding_state"] == "transient_unbound"
+    assert snapshot["tracked_windows"][0]["visible"] is True
+    assert snapshot["tracked_windows"][0]["hidden"] is False
+    assert snapshot["tracked_windows"][0]["workspace"] == "1"
+    assert snapshot["outputs"][0]["workspaces"][0]["windows"][0]["id"] == 101
+    assert snapshot["outputs"][0]["workspaces"][0]["windows"][0]["binding_state"] == "transient_unbound"
 
 
 def make_local_payload():

--- a/home-modules/desktop/quickshell-runtime-shell/shell.qml
+++ b/home-modules/desktop/quickshell-runtime-shell/shell.qml
@@ -800,11 +800,11 @@ ShellRoot {
     }
 
     function barWorkspacesForOutput(outputName) {
-        const nativeWorkspaces = workspacesForScreen(findScreenByOutputName(outputName));
-        if (nativeWorkspaces.length > 0) {
-            return nativeWorkspaces;
+        const dashboardWorkspaces = dashboardWorkspacesForOutput(outputName);
+        if (dashboardWorkspaces.length > 0) {
+            return dashboardWorkspaces;
         }
-        return dashboardWorkspacesForOutput(outputName);
+        return workspacesForScreen(findScreenByOutputName(outputName));
     }
 
     function currentLayoutLabel() {


### PR DESCRIPTION
## Summary
- make tracked windows authoritative for workspace window projection
- preserve managed terminal visibility when Sway reports a transient no-workspace move
- make the bottom bar use daemon-projected workspaces instead of a separate native path

## Testing
- python -m py_compile home-modules/desktop/i3-project-event-daemon/handlers.py home-modules/desktop/i3-project-event-daemon/state.py home-modules/desktop/i3-project-event-daemon/ipc_server.py
- pytest -q home-modules/desktop/i3-project-event-daemon/tests/unit/test_handlers_window_move.py home-modules/desktop/i3-project-event-daemon/tests/unit/test_ipc_server_session_list.py
- pytest -q home-modules/desktop/i3-project-event-daemon/tests/unit/test_ipc_server_focus.py home-modules/desktop/i3-project-event-daemon/tests/unit/test_ipc_server_session_preview.py
- sudo nixos-rebuild switch --flake .#thinkpad