### PR TITLE
Remove retired Workflow MCP compatibility guidance

### DIFF
--- a/shared-skills/gitops/runbooks/debug-workflow-builder-mcp-auth.md
+++ b/shared-skills/gitops/runbooks/debug-workflow-builder-mcp-auth.md
@@ -34,16 +34,6 @@ An already-running session keeps its existing bootstrap: `spawnSessionWorkflow`
 returns early on retry and does not refresh the token. Start a fresh session
 after a staged Workflow MCP credential/auth rollout.
 
-Dev may temporarily set `WORKFLOW_MCP_LEGACY_RUNTIME_COMPAT_UNTIL` to an
-absolute cutoff no more than 48 hours ahead. This is a route-opt-in bridge for
-selected direct internal BFF operations owned by already-running pre-token
-sessions. The BFF rechecks ownership, nonterminal session state, and current
-membership, then grants only the minimal resource-specific scope. It grants no
-team capability or arbitrary script depth. The flag is not an external MCP
-authentication mechanism, and `X-Wfb-Session-Id` alone remains invalid at the
-Workflow MCP endpoint. New sessions must use signed credentials; remove the
-flag after the migration window.
-
 Do not confuse Workflow Builder `sessions.id` with Streamable HTTP
 `Mcp-Session-Id` or an AI-client thread ID.
 

--- a/shared-skills/workflow-builder/references/workflow-mcp-server.md
+++ b/shared-skills/workflow-builder/references/workflow-mcp-server.md
@@ -77,20 +77,6 @@ Platform-spawned agents receive a signed, session-bound bootstrap credential
 automatically. Users do not forge or supply it. Team role and script recursion
 depth are signed claims; raw headers do not grant those capabilities.
 
-During a staged dev rollout only, `WORKFLOW_MCP_LEGACY_RUNTIME_COMPAT_UNTIL`
-may set an absolute compatibility cutoff no more than 48 hours in the future.
-That bridge lets selected direct internal BFF resource routes re-authorize an
-already-running pre-token session from database ownership and live membership.
-It grants only the minimal route-specific scope, no team capability, and no
-arbitrary recursion depth. It is **not** accepted by the external Workflow MCP
-endpoint, does not turn `X-Wfb-Session-Id` into a credential, and must be absent
-after the cutoff. New sessions always use signed bootstrap credentials.
-
-Roll out the BFF issuer and bounded compatibility first, then the MCP
-enforcement image. Drain or restart pre-token clients and remove the temporary
-flag after the migration window; do not merge these client instructions ahead
-of the corresponding workflow-builder and stacks changes.
-
 ## Do not confuse these IDs
 
 | ID | Meaning | Workflow owner or credential? |


### PR DESCRIPTION
## Summary
- remove the expired dev-only Workflow MCP compatibility bridge from the client reference
- remove the same retired migration path from the GitOps authentication runbook
- keep workspace API-key authentication, sessionless workflow operations, optional verified lineage context, and signed platform-agent credentials as the authoritative contract

## Validation
- `git diff --check`
- residual shared-skill audit found no other stale Kimi, GLM browser-agent, pydantic-agent-py, sessionId, Ryzen target, Crossplane, DevSpace, Gitea, or goal-cron guidance requiring removal

No NixOS activation or cluster change is included.