### PR TITLE
docs(skills): align K3 preview and trace guidance

### DIFF
--- a/shared-skills/preview-environments/SKILL.md
+++ b/shared-skills/preview-environments/SKILL.md
@@ -44,6 +44,48 @@ the active implementation.
 Choose the smallest profile that answers the question. Do not use a host
 candidate to test an ordinary service edit.
 
+`host-candidate` is not a vCluster launch mode. Its dedicated host adapter and
+receipt boundary must reject attempts to route it through the app-live runner.
+
+## Workflow MCP Operations
+
+Use the BFF-authorized Workflow MCP tools instead of Kubernetes discovery for
+normal lifecycle work:
+
+1. `list_preview_services`, then `list_preview_environments`.
+2. `launch_preview_environment`, followed by `get_preview_environment` until
+   the accepted generation is Ready.
+3. `debug_preview_environment` for the bounded lifecycle/runtime/trace bundle,
+   then `query_preview_traces` for explicit service, status, search, and time
+   filters.
+4. Read the generation again immediately before teardown. Pass its exact
+   `provenance.requestId` and `sourceRevision` to
+   `teardown_preview_environment`, then poll the returned signed ticket with
+   `get_preview_teardown_status` until all twelve checks are true.
+
+Honor `telemetry.refreshAfterMs`, generation-fence warnings, pagination, and
+server-issued `nextActions`. A partial or `7/12` cleanup snapshot can be a
+normal transition between dev-side physical cleanup and hub finalizer
+convergence; only `12/12` is terminal proof.
+
+The physical dev workspace key is never forwarded into a preview. A direct
+preview-local Workflow MCP connection uses a preview-local key and audience.
+Its standard execution/trace tools keep authorization in the preview while
+deep evidence is read through the tuple-bound physical diagnostics adapter.
+
+## Preview Runtime Boundary
+
+An `app-live` vCluster does not inherit the physical host OpenShell or
+`workspace-runtime`. Do not restore host credentials or host workspace URLs to
+make an agent call pass. For preview-local agent proofs, confirm the selected
+runtime is the preview-native `dapr-agent-py-juicefs` lane and that Sandbox
+Execution API receives the immutable environment tuple plus its tuple-scoped
+storage scope and class before launching the workflow.
+
+K3 vision analyzes pixels but does not navigate a browser. Keep the supported
+browser control/capture boundary, pass native screenshot image content to K3,
+and remove only obsolete model-specific text/metadata compensation.
+
 ## Lifecycle Workflow
 
 1. **Prepare.** Confirm dev health, host image/flags, preview capacity, source

--- a/shared-skills/workflow-builder/SKILL.md
+++ b/shared-skills/workflow-builder/SKILL.md
@@ -52,6 +52,28 @@ Prefer Workflow MCP or the UI. The bundled
 path for an access JWT or cookie; it intentionally rejects workspace keys and
 has no Postgres fallback.
 
+## Kimi K3 Contract
+
+Resolve the current model route from source and live runtime evidence before
+making a claim. When a call resolves to `kimi/kimi-k3`, require the complete
+platform contract:
+
+- `contextWindowTokens` is `1048576` and `reasoningEffort` is `max`; a lower
+  per-call effort must not downgrade K3.
+- Schema-bearing dynamic-script calls use K3 as the default structured-output
+  route and retain the resolved structured-output mode and schema validation.
+- Authentication comes only from `KIMI_API_KEY` through the owning secret and
+  deployment path. Never copy the key into workflow input, agent config, logs,
+  fixtures, or a preview.
+- Multimodal messages keep native content arrays. Images must reach K3 as
+  structured image objects containing supported base64 data URIs or uploaded
+  file references, not JSON-stringified screenshot metadata.
+
+Vision is not browser control. Use the current browser runtime or catalog
+actions to navigate and capture pixels, then pass the resulting image content
+to K3. Remove model-specific text-only browser workarounds only after proving
+the supported control and capture path still covers the workflow.
+
 ## Task Map
 
 | Task                             | Read or inspect                                                                        |
@@ -98,15 +120,27 @@ has no Postgres fallback.
 
 For a failed or silent run, inspect in order:
 
-1. Saved workflow engine, script, metadata, and validation result.
-2. Authenticated workspace and optional session attachment.
-3. Execution row, durable instance ID, current node, and failure payload.
-4. Orchestrator logs and script journal/replay state.
-5. Saved agent version, runtime-registry resolution, model, and MCP/tool config.
-6. Kueue Workload, Sandbox, pod scheduling, init containers, and both app and
-   `daprd` logs.
-7. Session events, tool calls, usage, artifacts, and terminal status.
-8. User-facing API/UI state.
+1. Call `get_workflow_context`, then use `list_workflow_executions` only when
+   the exact execution ID is unknown.
+2. Call `debug_workflow_execution` for the bounded overview and server-issued
+   `nextActions`, followed by `trace_get_digest` for phases, usage, critical
+   path, and evidence coverage.
+3. Drill down narrowly with `trace_search_spans`, `trace_get_span`, and
+   `trace_get_logs`. Use returned cursors rather than requesting an unbounded
+   trace.
+4. For model evidence, call `trace_get_llm_turn` with exactly one of `spanId`
+   or `sessionId`. For browser evidence, call
+   `trace_get_browser_screenshot` with an execution-bound storage reference;
+   it returns native MCP image content for vision analysis.
+5. Compare the MCP evidence with the saved workflow engine, script, metadata,
+   validation result, durable instance, current node, and replay journal.
+6. Verify saved-agent version, runtime-registry resolution, effective model
+   config, MCP/tool config, session events, usage, artifacts, and terminal
+   status.
+7. Only then inspect Kueue Workload, Sandbox, pod scheduling, init containers,
+   orchestrator/runtime logs, and both app and `daprd` containers when the
+   bounded product evidence identifies a runtime gap.
+8. Confirm the same result through the user-facing API/UI state.
 
 Normal replay messages are not proof of a hang. Prove lack of progress with
 durable state, timestamps, queue admission, and runtime logs before intervening.

--- a/shared-skills/workflow-builder/evals/evals.json
+++ b/shared-skills/workflow-builder/evals/evals.json
@@ -3,8 +3,8 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Build a dynamic-script workflow that accepts a URL, asks my saved browser agent for the page title and a short summary, saves it, and runs it.",
-      "expected_output": "Calls get_workflow_context and get_workflow_script_spec first; reads the current saved-agent/model contract instead of inventing a model key; writes a literal meta input schema and deterministic script; uses schema-constrained agent output; validates, saves, runs, and verifies the execution in the authenticated workspace; passes no sessionId as workflow ownership and performs no direct database write.",
+      "prompt": "Build a dynamic-script workflow that accepts a URL, uses our supported browser control and capture path, asks my saved Kimi K3 vision agent for the page title and a structured visual review, saves it, and runs it.",
+      "expected_output": "Calls get_workflow_context and get_workflow_script_spec first; discovers the current browser action/runtime and saved-agent contract instead of restoring a GLM browser agent or inventing a model key; keeps browser control separate from K3 vision; passes native screenshot image content rather than stringified metadata; verifies K3 max reasoning and 1048576-token context plus schema-constrained structured output; validates, saves, runs, and verifies the execution in the authenticated workspace; passes no sessionId as workflow ownership and performs no direct database write.",
       "files": []
     },
     {
@@ -16,7 +16,7 @@
     {
       "id": 3,
       "prompt": "A dynamic workflow's agent call never produces a response. Walk through diagnosis without changing cluster state first.",
-      "expected_output": "Checks script validation and execution state, saved-agent version and runtime-registry resolution, Kueue Workload and Sandbox admission, pod/init/app/daprd logs, MCP bootstrap, session events and usage, then UI state. It does not inspect or patch a retired AgentRuntime CR, create a per-agent state store, or treat normal replay chatter as proof of a hang.",
+      "expected_output": "Starts with get_workflow_context, discovers the exact run with list_workflow_executions only if needed, then uses debug_workflow_execution and trace_get_digest. It follows bounded nextActions into trace_search_spans, trace_get_span, trace_get_logs, and trace_get_llm_turn with exactly one spanId or sessionId before inspecting Kueue, Sandbox, pod/init/app/daprd logs. It verifies script state, saved-agent/runtime/model resolution, session events and usage, and UI state without patching a retired AgentRuntime CR, creating a per-agent state store, or treating normal replay chatter as proof of a hang.",
       "files": []
     },
     {


### PR DESCRIPTION
## Summary

- document the live Kimi K3 max-reasoning, 1,048,576-token, structured-output, and native vision contract
- teach Workflow Builder diagnosis to use the current bounded Workflow MCP trace tools before cluster inspection
- document the eight preview lifecycle/debug tools, generation-fenced 12-check teardown, and preview-local JuiceFS/OpenShell boundary
- refresh skill evaluations so they do not resurrect GLM browser agents or accept stringified screenshot metadata

## Architecture

The guidance preserves the existing ports/adapters boundary: Workflow MCP is the product-facing diagnostics/lifecycle adapter, preview identity remains host-derived, and provider credentials never enter workflows or previews.

## Validation

- `scripts/validate-shared-skills.py`
- upstream `quick_validate.py` for all eight skills
- `nix eval` for thinkpad and ryzen skill mappings (evaluation only; no rebuild)
- JSON parse and architecture source-anchor checks
- `git diff --check`
